### PR TITLE
Remove svg-partial-circle as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install react-minimal-pie-chart
 Because [Recharts](https://github.com/recharts/recharts) is awesome, but when you need just a simple pie/donought chart, few line of code are usually enough.
 
 ## Features
-- Just 1 micro dependency: [svg partial circle](https://github.com/derhuerst/svg-partial-circle)
+- No dependencies
 - Customizable CSS animations trough [stroke-dasharray + stroke-dashoffset strategy](https://css-tricks.com/svg-line-animation-works/)
 - Configurable: Pie, Donut, Loading, Completion charts (see [Demo][storybook])
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },
-  "dependencies": {
-    "svg-partial-circle": "^0.1.0"
-  },
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
     "babel-cli": "^6.23.0",

--- a/src/ReactMinimalPieChartPath.js
+++ b/src/ReactMinimalPieChartPath.js
@@ -1,8 +1,22 @@
 import React, { PropTypes } from 'react';
-import partialCircle from 'svg-partial-circle';
 
 const PI = Math.PI;
 const degreesToRadians = degrees => ((degrees * PI) / 180);
+
+// from http://stackoverflow.com/a/18473154
+const partialCircle = (cx, cy, r, start, end) => {
+	const fromX = cx + r * Math.cos(end)
+	const fromY = cy + r * Math.sin(end)
+	const toX = cx + r * Math.cos(start)
+	const toY = cy + r * Math.sin(start)
+	const large = (end - start) <= Math.PI ? '0' : '1'
+
+	if ((end - start) === 0) return []
+	return [
+		['M', fromX, fromY],
+		['A', r, r, 0, large, 0, toX, toY]
+	]
+}
 
 const makePathCommands = (cx, cy, startAngle, lengthAngle, radius, paddingAngle) => {
   // Let svg-partial-circle evaluate "d" value


### PR DESCRIPTION
I suggest removing the ```svg-partial-circle``` dependency. The only thing it does is exposing one function copied from stackoverflow, and it exposes the function as an arrow function without being transpiled (or uglified/minified). So when I tried to use you package in a [create-react-app](https://github.com/facebookincubator/create-react-app) project, the build broke because of it.

And its fancier with no dependencies than one dependency :v: 