### PR TITLE
ReactMinimalPieChart: make SVG display: block

### DIFF
--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -125,6 +125,7 @@ export default class ReactMinimalPieChart extends PureComponent {
           viewBox={`0 0 ${evaluateViewBoxSize(this.props.ratio, VIEWBOX_SIZE)}`}
           width="100%"
           height="100%"
+          style={{ display: 'block' }}
         >
           {makeSegments(normalizedData, this.props, this.hideSegments)}
         </svg>


### PR DESCRIPTION
SVGs are images, which are display: inline. The means there is a couple
pixels of added padding on the bottom. This causes issues when try to
align the pie chart with other components.