### PR TITLE
Prevent initial animation when component is unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.2
+- Prevent initial animation when component is unmounted
+
 # 3.0.1
 - Update `react`/`react-dom` peer dependency version to accept versions `15` and `16`
 

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -93,8 +93,10 @@ export default class ReactMinimalPieChart extends PureComponent {
     if (this.props.animate === true && requestAnimationFrame) {
       this.initialAnimationTimerId = setTimeout(
         () => {
+          this.initialAnimationTimerId = null;
           this.initialAnimationRAFId = requestAnimationFrame(
             () => {
+              this.initialAnimationRAFId = null,
               this.startAnimation();
             }
           )

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -91,11 +91,24 @@ export default class ReactMinimalPieChart extends PureComponent {
 
   componentDidMount() {
     if (this.props.animate === true && requestAnimationFrame) {
-      setTimeout(
-        () => requestAnimationFrame(
-          this.startAnimation.bind(this)
-        )
+      this.initialAnimationTimerId = setTimeout(
+        () => {
+          this.initialAnimationRAFId = requestAnimationFrame(
+            () => {
+              this.startAnimation();
+            }
+          )
+        }
       );
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.initialAnimationTimerId) {
+      clearTimeout(this.initialAnimationTimerId);
+    }
+    if (this.initialAnimationRAFId) {
+      cancelAnimationFrame(this.initialAnimationRAFId);
     }
   }
 


### PR DESCRIPTION
### What kind of change does this PR introduce? 
Bug

### What is the current behaviour?
#8 

### What is the new behaviour?
Cancel both `setTimeout` and `requestAnimationFrame` async callbacks on unmount if still pending


### Please check if the PR fulfills these requirements:
- [X] Tests for the changes have been added
