### PR TITLE
Remove key property for basic use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ import PieChart from 'react-minimal-pie-chart';
 
 <PieChart
   data={[
-    { value: 10, key: 1, color: '#E38627' },
-    { value: 15, key: 2, color: '#C13C37' },
-    { value: 20, key: 3, color: '#6A2135' },
+    { value: 10, color: '#E38627' },
+    { value: 15, color: '#C13C37' },
+    { value: 20, color: '#6A2135' },
   ]}
 />
 ```
@@ -49,6 +49,12 @@ Property | Type | Description | Default
 **animationDuration** | *Number* | Animation duration in ms | 500
 **animationEasing** | *String* | Animation CSS easing | "ease-out"
 **reveal** | *Number* | Turn on CSS animation and reveal just a percentage of each segment| -
+
+Each **data** entry can also accept an **optional [`key` property](https://reactjs.org/docs/lists-and-keys.html)** just in case items' indexes weren't enough:
+
+```js
+{ value: 10, key: 1, color: '#E38627' }
+```
 
 ## Browsers support
 The main requirement of this library is an accurate rendering of [SVG Stroke properties](https://www.w3schools.com/graphics/svg_stroking.asp).

--- a/src/__tests__/ReactMinimalPieChart.js
+++ b/src/__tests__/ReactMinimalPieChart.js
@@ -4,9 +4,9 @@ import { shallow } from 'enzyme';
 import PieChart from '../index';
 
 const dataMock = [
-  { value: 10, key: 1, color: 'blue' },
-  { value: 15, key: 2, color: 'orange' },
-  { value: 20, key: 3, color: 'green' },
+  { value: 10, color: 'blue' },
+  { value: 15, color: 'orange' },
+  { value: 20, color: 'green' },
 ];
 
 const styleMock = {

--- a/stories/index.js
+++ b/stories/index.js
@@ -14,9 +14,9 @@ const ContainDecorator = (story) => (
 );
 
 const dataMock = [
-  { value: 10, key: 1, color: '#E38627' },
-  { value: 15, key: 2, color: '#C13C37' },
-  { value: 20, key: 3, color: '#6A2135' },
+  { value: 10, color: '#E38627' },
+  { value: 15, color: '#C13C37' },
+  { value: 20, color: '#6A2135' },
 ];
 
 storiesOf('React minimal pie chart', module)


### PR DESCRIPTION
### What kind of change does this PR introduce?
 docs/tests update

### What is the current behaviour? *(You can also link to an open issue here)*
Current docs and tests using this `data` as basic example:

```js
[
    { value: 10, key: 1, color: '#E38627' },
    { value: 15, key: 2, color: '#C13C37' },
    { value: 20, key: 3, color: '#6A2135' },
]
```

It turns out that **`key` property should not be not necessary in 99% of use cases**.

### What is the new behaviour?
- Remove test properties from both docs and tests data objects.
- Add a note to docs about what is `key` property for and to use it

### Does this PR introduce a breaking change? *(What changes might users need to make in their application due to this PR?)*
No

### Please check if the PR fulfills these requirements:
- [X] Tests for the changes have been added
- [X] Docs have been added / updated
