### PR TITLE
add onMouseOver & onMouseOut

### DIFF
--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -56,6 +56,9 @@ const makeSegments = (data, props, hide) => {
   } else if (hide === false) {
     reveal = 100;
   }
+  
+  const onMouseOver = props.onMouseOver || (() => {})
+  const onMouseOut = props.onMouseOut || (() => {})
 
   return data.map((dataEntry, index) => {
     const startAngle = lastSegmentAngle;
@@ -75,6 +78,8 @@ const makeSegments = (data, props, hide) => {
         stroke={dataEntry.color}
         strokeLinecap={props.rounded ? 'round' : undefined}
         fill="none"
+        onMouseOver={e => onMouseOver(e, dataEntry, index)}
+        onMouseOut={e => onMouseOut(e, dataEntry, index)}
       />
     );
   });
@@ -184,6 +189,8 @@ ReactMinimalPieChart.propTypes = {
   animationEasing: PropTypes.string,
   reveal: PropTypes.number,
   children: PropTypes.node,
+  onMouseOver: PropTypes.func,
+  onMouseOut: PropTypes.func,
 };
 
 ReactMinimalPieChart.defaultProps = {


### PR DESCRIPTION
### What kind of change does this PR introduce? *(Bug fix, feature, docs update, ...)*
Feature.

This adds `onMouseOver` & `onMouseOut` for segments, with `(event, data, index)` as params. This will enable things like tooltips or fancy dynamic styling.

### What is the current behaviour? *(You can also link to an open issue here)*

No way to respond to mouse in/out

### What is the new behaviour?

It responds to  mouse in/out

### Does this PR introduce a breaking change? *(What changes might users need to make in their application due to this PR?)*

No. it works as before, but with a couple new props.

### Other information:

Sorry, I didn't add docs/tests, as this is a quick feature I added to my own copy, that I thought might be useful to others. If I have more time later, I'd be willing to write docs/test, but usage should be straightforward if someone else wants to do it.

### Please check if the PR fulfills these requirements:
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
