### PR TITLE
Support data.title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.0
+
+- Support `data.title` property to render `<title>` inside `<path>` element
+
 # 3.2.0
 
 - Add UMD export

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ import PieChart from 'react-minimal-pie-chart';
 
 <PieChart
   data={[
-    { value: 10, color: '#E38627' },
-    { value: 15, color: '#C13C37' },
-    { value: 20, color: '#6A2135' },
+    { title: 'One', value: 10, color: '#E38627' },
+    { title: 'Two', value: 15, color: '#C13C37' },
+    { title: 'Three', value: 20, color: '#6A2135' },
   ]}
 />;
 ```

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -183,6 +183,7 @@ ReactMinimalPieChart.displayName = 'ReactMinimalPieChart';
 ReactMinimalPieChart.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
+      title: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       value: PropTypes.number.isRequired,
       key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       color: PropTypes.string,

--- a/src/ReactMinimalPieChartPath.js
+++ b/src/ReactMinimalPieChartPath.js
@@ -30,6 +30,7 @@ export default function ReactMinimalPieChartPath({
   radius,
   lineWidth,
   reveal,
+  title,
   ...props
 }) {
   const actualRadio = radius - lineWidth / 2;
@@ -57,7 +58,9 @@ export default function ReactMinimalPieChartPath({
       strokeDasharray={strokeDasharray}
       strokeDashoffset={strokeDashoffset}
       {...props}
-    />
+    >
+      {title && <title>{title}</title>}
+    </path>
   );
 }
 
@@ -71,6 +74,7 @@ ReactMinimalPieChartPath.propTypes = {
   radius: PropTypes.number,
   lineWidth: PropTypes.number,
   reveal: PropTypes.number,
+  title: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 ReactMinimalPieChartPath.defaultProps = {

--- a/src/__tests__/ReactMinimalPieChartPath.js
+++ b/src/__tests__/ReactMinimalPieChartPath.js
@@ -69,4 +69,19 @@ describe('ReactMinimalPieChartPath component', () => {
     const strokeDasharray = wrapper.prop('strokeDasharray');
     expect(strokeDashoffset).toEqual(strokeDasharray + strokeDasharray / 4);
   });
+
+  it('Should render a <Title> element when "title" prop provided', () => {
+    const wrapper = shallow(
+      <PieChartPath
+        cx={100}
+        cy={100}
+        title="title-value"
+      />
+    );
+
+    const title = wrapper.find('title');
+
+    expect(title.length).toEqual(1);
+    expect(title.text()).toEqual('title-value');
+  });
 });


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_
feature

### What is the new behaviour?
Support `data.title` property to render `<title>` inside `<path>` element

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_
Very unlikely. `data.title` values will be rendered in a `<title>` element inside the relevant segment.

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
