### PR TITLE
Support injectSvg property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.0
+
+- Support `injectSvg` function property to inject any element into rendered `<svg>` element
+
 # 3.3.0
 
 - Support `data.title` property to render `<title>` inside `<path>` element

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Because [Recharts](https://github.com/recharts/recharts) is awesome, but when yo
 | **animationDuration** | _Number_   | Animation duration in ms                                                                                        | 500        |
 | **animationEasing**   | _String_   | Animation CSS easing                                                                                            | "ease-out" |
 | **reveal**            | _Number_   | Turn on CSS animation and reveal just a percentage of each segment                                              | -          |
+| **injectSvg**         | _Function_ | Inject <svg>` element with the output of the provided function (eg. gradients) | -                              |
 | **onClick**           | _Function_ | Custom event handler of `onClick` on each sector : `(event, data, dataIndex) => {}`                             | -          |
 | **onMouseOver**       | _Function_ | Custom event handler of `onMouseOver` on each sector : `(event, data, dataIndex) => {}`                         | -          |
 | **onMouseOut**        | _Function_ | Custom event handler of `onMouseOut` on each sector : `(event, data, dataIndex) => {}`                          | -          |
@@ -98,6 +99,7 @@ http://users.ecs.soton.ac.uk/rfp07r/interactive-svg-examples/
 - Find a better `paddingAngle` implementation
 - Make a device/browser compatibility table
 - Background segment
+- Consider switching `ReactMinimalPieChart` to extend default `React.Component`
 
 ## Contributors
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postversion": "git push && git push --tags",
     "prepublish": "npm run test:source && npm run compile && npm run test:bundles",
     "precommit": "lint-staged && npm test",
-    "storybook": "start-storybook -p 9001 -c .storybook",
+    "start": "start-storybook -p 9001 -c .storybook",
     "build-storybook": "build-storybook -o ./.out"
   },
   "keywords": [

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -171,6 +171,7 @@ export default class ReactMinimalPieChart extends PureComponent {
           style={{ display: 'block' }}
         >
           {makeSegments(normalizedData, this.props, this.hideSegments)}
+          {this.props.injectSvg && this.props.injectSvg()}
         </svg>
         {this.props.children}
       </div>
@@ -211,6 +212,7 @@ ReactMinimalPieChart.propTypes = {
   animationEasing: PropTypes.string,
   reveal: PropTypes.number,
   children: PropTypes.node,
+  injectSvg: PropTypes.func,
   onMouseOver: PropTypes.func,
   onMouseOut: PropTypes.func,
   onClick: PropTypes.func,

--- a/src/__tests__/ReactMinimalPieChart.js
+++ b/src/__tests__/ReactMinimalPieChart.js
@@ -237,6 +237,21 @@ describe('ReactMinimalPieChart component', () => {
     });
   });
 
+  describe('"injectSvg"', () => {
+    it('Should inject anything into rendered <svg>', () => {
+      const wrapper = shallow(
+        <PieChart
+          data={dataMock}
+          injectSvg={() => <defs />}
+        />
+      );
+
+      const svg = wrapper.find('svg').first();
+      const injectedElement = svg.find('defs');
+      expect(injectedElement.length).toEqual(1);
+    });
+  });
+
   describe('Mouse interactions', () => {
     [
       { eventName: 'onClick', enzymeAction: 'click' },

--- a/stories/index.js
+++ b/stories/index.js
@@ -146,6 +146,62 @@ storiesOf('React minimal pie chart', module)
       animate
     />
   ))
+  .add('gradients with "injectSvg":', () => {
+    const dataMock = [
+      { value: 10, color: 'url(#gradient1)' },
+      { value: 20, color: 'url(#gradient2)' },
+    ];
+
+    return (
+      <PieChart
+        data={dataMock}
+        injectSvg={() => (
+          <defs>
+            <linearGradient
+              id="gradient1"
+              x1="100%"
+              y1="0%"
+              x2="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#E38627"
+              />
+              <stop
+                offset="50%"
+                stopColor="#ffb961"
+              />
+              <stop
+                offset="100%"
+                stopColor="#E38627"
+              />
+            </linearGradient>
+            <linearGradient
+              id="gradient2"
+              x1="100%"
+              y1="0%"
+              x2="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#C13C37"
+              />
+              <stop
+                offset="50%"
+                stopColor="#e35f56"
+              />
+              <stop
+                offset="100%"
+                stopColor="#C13C37"
+              />
+            </linearGradient>
+          </defs>
+        )}
+      />
+    );
+  })
   .add('Interaction using click/mouseOver/mouseOut', () => <DemoInteraction />)
   .add('as a loading bar with "reveal"', () => {
     const Wrapper = class Wrapper extends Component {


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Feature

### What is the current behaviour? _(You can also link to an open issue here)_

SVG paths support [gradient stroke color](https://www.w3schools.com/graphics/svg_grad_linear.asp) by appending a `<defs>` element into `<svg>` element.

Injecting custom elements into rendered `<svg>` element is currently impossible.

See issue #22.

### What is the new behaviour?

Add an `inject` (would `injectSvg` a better name?) property to render any custom element as `<svg>`children.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
