### PR TITLE
Fix missing data.title output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.1
+
+- Fix chart to render `data.title` value as `<title>` inside `<path>` element
+
 # 3.4.0
 
 - Support `injectSvg` function property to inject any element into rendered `<svg>` element

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -97,6 +97,7 @@ const makeSegments = (data, props, hide) => {
         radius={props.radius}
         lineWidth={(props.radius / 100) * props.lineWidth}
         reveal={reveal}
+        title={dataEntry.title}
         style={style}
         stroke={dataEntry.color}
         strokeLinecap={props.rounded ? 'round' : undefined}

--- a/src/__tests__/ReactMinimalPieChart.js
+++ b/src/__tests__/ReactMinimalPieChart.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import PieChart from '../../src/index';
 
@@ -234,6 +234,18 @@ describe('ReactMinimalPieChart component', () => {
       jest.runAllTimers();
 
       expect(chartInstance.startAnimation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('"data.title"', () => {
+    it('Should render a <Title> element in its Path', () => {
+      const wrapper = mount(
+        <PieChart data={[{ title: 'title-value', value: 10, color: 'blue' }]} />
+      );
+
+      const title = wrapper.find('title');
+      expect(title.length).toEqual(1);
+      expect(title.text()).toEqual('title-value');
     });
   });
 

--- a/src/__tests__/ReactMinimalPieChartPath.js
+++ b/src/__tests__/ReactMinimalPieChartPath.js
@@ -69,19 +69,4 @@ describe('ReactMinimalPieChartPath component', () => {
     const strokeDasharray = wrapper.prop('strokeDasharray');
     expect(strokeDashoffset).toEqual(strokeDasharray + strokeDasharray / 4);
   });
-
-  it('Should render a <Title> element when "title" prop provided', () => {
-    const wrapper = shallow(
-      <PieChartPath
-        cx={100}
-        cy={100}
-        title="title-value"
-      />
-    );
-
-    const title = wrapper.find('title');
-
-    expect(title.length).toEqual(1);
-    expect(title.text()).toEqual('title-value');
-  });
 });

--- a/stories/index.js
+++ b/stories/index.js
@@ -17,9 +17,9 @@ const ContainDecorator = story => (
 );
 
 const dataMock = [
-  { value: 10, color: '#E38627' },
-  { value: 15, color: '#C13C37' },
-  { value: 20, color: '#6A2135' },
+  { title: 'One', value: 10, color: '#E38627' },
+  { title: 'Two', value: 15, color: '#C13C37' },
+  { title: 'Three', value: 20, color: '#6A2135' },
 ];
 
 class DemoInteraction extends Component {


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Fix

### What is the current behaviour? _(You can also link to an open issue here)_

Missing `<path>` > `<title>` element when `data.title` is provided

### What is the new behaviour?

Provide `title` prop to `<ReactMinimalPieChartPath>` component

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
