### PR TITLE
Let <ReactMinimalPieChart> extend React.Component class

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ let plugins = [
   commonjs({
     // https://github.com/reactjs/react-redux/issues/643#issuecomment-285008041
     namedExports: {
-      'node_modules/react/react.js': ['PureComponent'],
+      'node_modules/react/react.js': ['Component'],
     },
   }),
 ];

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Path from './ReactMinimalPieChartPath';
 import DefaultLabel from './ReactMinimalPieChartLabel';
@@ -157,7 +157,7 @@ const makeLabels = (data, props) => {
   });
 };
 
-export default class ReactMinimalPieChart extends PureComponent {
+export default class ReactMinimalPieChart extends Component {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Refactor

### What is the current behaviour? _(You can also link to an open issue here)_

`<ReactMinimalPieChart>` extends React.PureComponent class

### What is the new behaviour?

`<ReactMinimalPieChart>`extends React.Component class. 

 Extending React.PureComponent was premature optimisation.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes

### Other information:

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
