### PR TITLE
Improve paddingAngle implementation to respect slices' proportions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ const labelProps = {
   data: {
     // props.data array extended with:
     degrees: number,
+    startOffset: number,
     percentage: number,
   }[],
   dataIndex: number,

--- a/src/ReactMinimalPieChart.js
+++ b/src/ReactMinimalPieChart.js
@@ -18,16 +18,33 @@ function sumValues(data) {
   return data.reduce((acc, dataEntry) => acc + dataEntry.value, 0);
 }
 
-function evaluateDegreesFromValues(data, totalAngle, totalValue) {
+// Append "percentage", "degrees" and "startOffset" into each data entry
+function extendData({
+  data,
+  lengthAngle: totalAngle,
+  totalValue,
+  paddingAngle,
+}) {
   const total = totalValue || sumValues(data);
   const normalizedTotalAngle = valueBetween(totalAngle, -360, 360);
+  const numberOfPaddings =
+    Math.abs(normalizedTotalAngle) === 360 ? data.length : data.length - 1;
+  const degreesTakenByPadding =
+    Math.abs(paddingAngle) * numberOfPaddings * Math.sign(normalizedTotalAngle);
+  const singlePaddingDegrees = degreesTakenByPadding / numberOfPaddings;
+  const degreesTakenByPaths = normalizedTotalAngle - degreesTakenByPadding;
+  let lastSegmentEnd = 0;
 
-  // Append "degrees" and "percentage" into each data entry
   return data.map(dataEntry => {
     const valueInPercentage = (dataEntry.value / total) * 100;
+    const degrees = extractPercentage(degreesTakenByPaths, valueInPercentage);
+    const startOffset = lastSegmentEnd;
+    lastSegmentEnd = lastSegmentEnd + degrees + singlePaddingDegrees;
+
     return {
       percentage: valueInPercentage,
-      degrees: extractPercentage(normalizedTotalAngle, valueInPercentage),
+      degrees,
+      startOffset,
       ...dataEntry,
     };
   });
@@ -47,63 +64,6 @@ function makeSegmentTransitionStyle(duration, easing, furtherStyles = {}) {
   };
 }
 
-function makeSegments(data, props, hide) {
-  // Keep track of how many degrees have already been taken
-  let lastSegmentAngle = props.startAngle;
-  const paddingAngle = props.paddingAngle * Math.sign(props.lengthAngle);
-  let reveal;
-  let style = props.segmentsStyle;
-
-  if (props.animate) {
-    const transitionStyle = makeSegmentTransitionStyle(
-      props.animationDuration,
-      props.animationEasing,
-      style
-    );
-    style = Object.assign({}, style, transitionStyle);
-  }
-
-  // Hide/reveal the segment?
-  if (hide === true) {
-    reveal = 0;
-  } else if (typeof props.reveal === 'number') {
-    reveal = props.reveal;
-  } else if (hide === false) {
-    reveal = 100;
-  }
-
-  return data.map((dataEntry, index) => {
-    const startAngle = lastSegmentAngle;
-    const lengthAngle = dataEntry.degrees;
-    lastSegmentAngle += lengthAngle;
-
-    return (
-      <Path
-        key={dataEntry.key || index}
-        cx={props.cx}
-        cy={props.cy}
-        startAngle={startAngle}
-        lengthAngle={lengthAngle - paddingAngle}
-        radius={props.radius}
-        lineWidth={extractPercentage(props.radius, props.lineWidth)}
-        reveal={reveal}
-        title={dataEntry.title}
-        style={style}
-        stroke={dataEntry.color}
-        strokeLinecap={props.rounded ? 'round' : undefined}
-        fill="none"
-        onMouseOver={
-          props.onMouseOver && (e => props.onMouseOver(e, props.data, index))
-        }
-        onMouseOut={
-          props.onMouseOut && (e => props.onMouseOut(e, props.data, index))
-        }
-        onClick={props.onClick && (e => props.onClick(e, props.data, index))}
-      />
-    );
-  });
-}
-
 function renderLabelItem(option, props, value) {
   if (React.isValidElement(option)) {
     return React.cloneElement(option, props);
@@ -120,18 +80,12 @@ function renderLabelItem(option, props, value) {
   return <DefaultLabel {...props}>{label}</DefaultLabel>;
 }
 
-function makeLabels(data, props) {
-  // Keep track of how many degrees have already been taken
-  let lastSegmentAngle = props.startAngle;
-  const paddingAngle = props.paddingAngle * Math.sign(props.lengthAngle);
+function renderLabels(data, props) {
   const labelPosition = extractPercentage(props.radius, props.labelPosition);
 
   return data.map((dataEntry, index) => {
-    const startAngle = lastSegmentAngle;
-    const lengthAngle = dataEntry.degrees;
-    lastSegmentAngle += lengthAngle;
-
-    const halfAngle = startAngle + (lengthAngle - paddingAngle) / 2;
+    const startAngle = props.startAngle + dataEntry.startOffset;
+    const halfAngle = startAngle + dataEntry.degrees / 2;
     const halfAngleRadians = degreesToRadians(halfAngle);
     const dx = Math.cos(halfAngleRadians) * labelPosition;
     const dy = Math.sin(halfAngleRadians) * labelPosition;
@@ -155,6 +109,58 @@ function makeLabels(data, props) {
     };
 
     return renderLabelItem(props.label, labelProps, dataEntry.value);
+  });
+}
+
+function renderSegments(data, props, hide) {
+  let style = props.segmentsStyle;
+  let reveal;
+
+  if (props.animate) {
+    const transitionStyle = makeSegmentTransitionStyle(
+      props.animationDuration,
+      props.animationEasing,
+      style
+    );
+    style = Object.assign({}, style, transitionStyle);
+  }
+
+  // Hide/reveal the segment?
+  if (hide === true) {
+    reveal = 0;
+  } else if (typeof props.reveal === 'number') {
+    reveal = props.reveal;
+  } else if (hide === false) {
+    reveal = 100;
+  }
+
+  return data.map((dataEntry, index) => {
+    const startAngle = props.startAngle + dataEntry.startOffset;
+
+    return (
+      <Path
+        key={dataEntry.key || index}
+        cx={props.cx}
+        cy={props.cy}
+        startAngle={startAngle}
+        lengthAngle={dataEntry.degrees}
+        radius={props.radius}
+        lineWidth={extractPercentage(props.radius, props.lineWidth)}
+        reveal={reveal}
+        title={dataEntry.title}
+        style={style}
+        stroke={dataEntry.color}
+        strokeLinecap={props.rounded ? 'round' : undefined}
+        fill="none"
+        onMouseOver={
+          props.onMouseOver && (e => props.onMouseOver(e, props.data, index))
+        }
+        onMouseOut={
+          props.onMouseOut && (e => props.onMouseOut(e, props.data, index))
+        }
+        onClick={props.onClick && (e => props.onClick(e, props.data, index))}
+      />
+    );
   });
 }
 
@@ -196,12 +202,7 @@ export default class ReactMinimalPieChart extends Component {
     if (this.props.data === undefined) {
       return null;
     }
-
-    const normalizedData = evaluateDegreesFromValues(
-      this.props.data,
-      this.props.lengthAngle,
-      this.props.totalValue
-    );
+    const extendedData = extendData(this.props);
 
     return (
       <div
@@ -214,8 +215,8 @@ export default class ReactMinimalPieChart extends Component {
           height="100%"
           style={{ display: 'block' }}
         >
-          {makeSegments(normalizedData, this.props, this.hideSegments)}
-          {this.props.label && makeLabels(normalizedData, this.props)}
+          {renderSegments(extendedData, this.props, this.hideSegments)}
+          {this.props.label && renderLabels(extendedData, this.props)}
           {this.props.injectSvg && this.props.injectSvg()}
         </svg>
         {this.props.children}

--- a/src/__tests__/ReactMinimalPieChart.js
+++ b/src/__tests__/ReactMinimalPieChart.js
@@ -17,6 +17,7 @@ const expectedNormalizedDataMock = {
   data: dataMock.map(entry => ({
     ...entry,
     degrees: expect.any(Number),
+    startOffset: expect.any(Number),
     percentage: expect.any(Number),
   })),
   dataIndex: expect.any(Number),
@@ -38,20 +39,20 @@ beforeAll(() => {
 });
 
 describe('ReactMinimalPieChart component', () => {
-  it('Should return null if props.data is undefined', () => {
+  it('returns null if props.data is undefined', () => {
     const wrapper = shallow(<PieChart />);
 
     expect(wrapper.getElement()).toEqual(null);
   });
 
-  it('Should return a Path component for each entry in props.data', () => {
+  it('returns a Path component for each entry in props.data', () => {
     const wrapper = shallow(<PieChart data={dataMock} />);
 
     const pathElements = wrapper.find('ReactMinimalPieChartPath');
     expect(pathElements.length).toEqual(dataMock.length);
   });
 
-  it('Should pass down className and style props to the wrapping div', () => {
+  it('passes down className and style props to the wrapping div', () => {
     const wrapper = shallow(
       <PieChart
         data={dataMock}
@@ -65,7 +66,7 @@ describe('ReactMinimalPieChart component', () => {
   });
 
   describe('<svg> element', () => {
-    it('Should be horizontal when "ratio" > 1', () => {
+    it('is horizontal when "ratio" > 1', () => {
       const wrapper = shallow(<PieChart
         data={dataMock}
         ratio={4}
@@ -75,7 +76,7 @@ describe('ReactMinimalPieChart component', () => {
       expect(svg.prop('viewBox')).toBe('0 0 100 25');
     });
 
-    it('Should be certical when "ratio" < 1', () => {
+    it('is certical when "ratio" < 1', () => {
       const wrapper = shallow(<PieChart
         data={dataMock}
         ratio={1 / 10}
@@ -87,7 +88,7 @@ describe('ReactMinimalPieChart component', () => {
   });
 
   describe('Partial circle', () => {
-    it('Should render a set of arc paths having total lengthAngle === 270°', () => {
+    it('renders a set of arc paths having total lengthAngle === 270°', () => {
       const pieLengthAngle = 270;
       let pathsTotalLengthAngle = 0;
 
@@ -106,7 +107,7 @@ describe('ReactMinimalPieChart component', () => {
       expect(pieLengthAngle).toEqual(pathsTotalLengthAngle);
     });
 
-    it('Should render a set of arc paths having total negative lengthAngle === -270°', () => {
+    it('renders a set of arc paths having total negative lengthAngle === -270°', () => {
       const pieLengthAngle = -270;
       let pathsTotalLengthAngle = 0;
 
@@ -124,11 +125,42 @@ describe('ReactMinimalPieChart component', () => {
 
       expect(pieLengthAngle).toEqual(pathsTotalLengthAngle);
     });
+  });
 
-    it('Should render a set of arc paths + paddings having total lengthAngle === 270°', () => {
-      const pieLengthAngle = 270;
+  describe('Rendered Paths', () => {
+    it('receives the custom "reveal" prop', () => {
+      const wrapper = shallow(<PieChart
+        data={dataMock}
+        reveal={22}
+      />);
+
+      wrapper.find('ReactMinimalPieChartPath').forEach(path => {
+        expect(path.prop('reveal')).toBe(22);
+      });
+    });
+
+    it('receives "style" prop', () => {
+      const styleMock = {
+        foo: 'bar',
+      };
+      const wrapper = shallow(
+        <PieChart
+          data={dataMock}
+          segmentsStyle={styleMock}
+        />
+      );
+
+      wrapper.find('ReactMinimalPieChartPath').forEach(path => {
+        expect(path.prop('style')).toEqual(styleMock);
+      });
+    });
+  });
+
+  describe('"paddingAngle"', () => {
+    it('renders a set of arc paths + paddings with total length === "lengthAngle"', () => {
+      const pieLengthAngle = 300;
       let pathsTotalLengthAngle = 0;
-      const totalPaddingDegrees = 10 * dataMock.length;
+      const totalPaddingDegrees = 10 * (dataMock.length - 1);
 
       const wrapper = shallow(
         <PieChart
@@ -149,38 +181,9 @@ describe('ReactMinimalPieChart component', () => {
     });
   });
 
-  describe('Rendered Paths', () => {
-    it('Should receive the custom "reveal" prop', () => {
-      const wrapper = shallow(<PieChart
-        data={dataMock}
-        reveal={22}
-      />);
-
-      wrapper.find('ReactMinimalPieChartPath').forEach(path => {
-        expect(path.prop('reveal')).toBe(22);
-      });
-    });
-
-    it('Should receive "style" prop', () => {
-      const styleMock = {
-        foo: 'bar',
-      };
-      const wrapper = shallow(
-        <PieChart
-          data={dataMock}
-          segmentsStyle={styleMock}
-        />
-      );
-
-      wrapper.find('ReactMinimalPieChartPath').forEach(path => {
-        expect(path.prop('style')).toEqual(styleMock);
-      });
-    });
-  });
-
   describe('"animate"', () => {
     describe('Segments "style.transition" prop', () => {
-      it('Should receive "stroke-dashoffset" transition prop with custom duration/easing', () => {
+      it('receives "stroke-dashoffset" transition prop with custom duration/easing', () => {
         const wrapper = shallow(
           <PieChart
             data={dataMock}
@@ -196,7 +199,7 @@ describe('ReactMinimalPieChart component', () => {
         expect(actual).toEqual(expected);
       });
 
-      it('Should merge autogenerated CSS transition prop with the one optionally provided by "segmentsStyle"', () => {
+      it('merges autogenerated CSS transition prop with the one optionally provided by "segmentsStyle"', () => {
         const wrapper = shallow(
           <PieChart
             data={dataMock}
@@ -216,7 +219,7 @@ describe('ReactMinimalPieChart component', () => {
       });
     });
 
-    it('Should render twice on mount updating segments "reveal" prop from 0 to 100', () => {
+    it('renders twice on mount updating segments "reveal" prop from 0 to 100', () => {
       const wrapper = shallow(<PieChart
         data={dataMock}
         animate
@@ -230,7 +233,7 @@ describe('ReactMinimalPieChart component', () => {
       expect(firstPath.prop('reveal')).toEqual(100);
     });
 
-    it('Should not fire forceUpdate on unmounted component', () => {
+    it('does not fire forceUpdate on unmounted component', () => {
       // Simulate edge case of animation fired after component was unmounted
       // See: https://github.com/toomuchdesign/react-minimal-pie-chart/issues/8
       const wrapper = shallow(<PieChart
@@ -249,7 +252,7 @@ describe('ReactMinimalPieChart component', () => {
   });
 
   describe('"data.title"', () => {
-    it('Should render a <Title> element in its Path', () => {
+    it('renders a <Title> element in its Path', () => {
       const wrapper = mount(
         <PieChart data={[{ title: 'title-value', value: 10, color: 'blue' }]} />
       );
@@ -262,7 +265,7 @@ describe('ReactMinimalPieChart component', () => {
 
   describe('"label"', () => {
     describe('true', () => {
-      it('Should render 3 <text> elements with expected text and "fill" attribute', () => {
+      it('renders 3 <text> elements with expected text and "fill" attribute', () => {
         const wrapper = mount(<PieChart
           data={dataMock}
           label
@@ -279,7 +282,7 @@ describe('ReactMinimalPieChart component', () => {
     });
 
     describe('provided as function', () => {
-      it('Should render 3 <text> elements with custom content', () => {
+      it('renders 3 <text> elements with custom content', () => {
         const wrapper = mount(
           <PieChart
             data={dataMock}
@@ -293,7 +296,7 @@ describe('ReactMinimalPieChart component', () => {
         });
       });
 
-      it('Provided function should receive expected "props" object', () => {
+      it('provided function receive expected "props" object', () => {
         const labelMock = jest.fn();
         mount(<PieChart
           data={dataMock}
@@ -311,7 +314,7 @@ describe('ReactMinimalPieChart component', () => {
     });
 
     describe('provided as component', () => {
-      it('Should render with expected props', () => {
+      it('renders with expected props', () => {
         const ComponentMock = jest.fn();
         const wrapper = shallow(
           <PieChart
@@ -331,7 +334,7 @@ describe('ReactMinimalPieChart component', () => {
   });
 
   describe('"labelStyle"', () => {
-    it('Should assign provided value to each label as className', () => {
+    it('assign provided value to each label as className', () => {
       const styleMock = { foo: 'bar' };
       const wrapper = mount(
         <PieChart
@@ -349,7 +352,7 @@ describe('ReactMinimalPieChart component', () => {
   });
 
   describe('"injectSvg"', () => {
-    it('Should inject anything into rendered <svg>', () => {
+    it('injects anything into rendered <svg>', () => {
       const wrapper = shallow(
         <PieChart
           data={dataMock}
@@ -370,7 +373,7 @@ describe('ReactMinimalPieChart component', () => {
       { eventName: 'onMouseOut', enzymeAction: 'mouseout' },
     ].forEach(test => {
       describe(test.eventName, () => {
-        it('Should its interaction callback with expected arguments', () => {
+        it('its interaction callback with expected arguments', () => {
           const eventMock = jest.fn();
           const eventCallbackMock = jest.fn();
           const wrapper = shallow(


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

`paddingAngle` implementation doesn't respect proportions of rendered slices.

### What is the new behaviour?

Re-evaluate rendered slices' degrees based on padding value

Add extra `startOffset` property to extended data set, in order to get rid of the pointers necessary to sequentially render the slices.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
