### PR TITLE
Replace export { default } syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
-export { default } from './ReactMinimalPieChart';
+import ReactMinimalPieChart from './ReactMinimalPieChart';
+export default ReactMinimalPieChart;


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

Typescript doesn't support `export { default } from` syntax

### What is the new behaviour?

Replace with normal import + export statement.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:
#39 

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
