### PR TITLE
Update dependency rollup to v1.16.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - "lts/*"
 script:
   - npm run prepublish
 notifications:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14645,7 +14645,6 @@
       "resolved": false,
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -14655,15 +14654,13 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -18282,14 +18279,22 @@
       }
     },
     "rollup": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.6.0.tgz",
-      "integrity": "sha512-qu9iWyuiOxAuBM8cAwLuqPclYdarIpayrkfQB7aTGTiyYPbvx+qVF33sIznfq4bxZCiytQux/FvZieUBAXivCw==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.16.4.tgz",
+      "integrity": "sha512-Bht8QXoo2dJc8lUGyEMfnfKCV7hkf1oLzN6L8YdDE2toaaoCe5DxoqYjTyKswWQyiZseViZw9quEdDRz0YXifw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^11.9.5",
+        "@types/node": "^12.0.10",
         "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.0.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
+          "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-babel": {
@@ -19942,7 +19947,7 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "optional": true

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prettier": "^1.18.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "rollup": "^1.0.0",
+    "rollup": "^1.16.4",
     "rollup-plugin-babel": "^4.0.0",
     "rollup-plugin-commonjs": "^9.0.0",
     "rollup-plugin-node-resolve": "^4.0.0",


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Dev dependencies update


### What is the new behaviour?

- Update `rollup` to allow renovate to update `rollup` plugins.
- Run CI against last LTS Node only

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
