### PR TITLE
Vertical align label with dominant-baseline

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -183,7 +183,7 @@ exports[`Dist bundle is unchanged 1`] = `
 
     return React__default.createElement(\\"text\\", _extends({
       textAnchor: \\"middle\\",
-      alignmentBaseline: \\"middle\\",
+      dominantBaseline: \\"middle\\",
       fill: color
     }, props));
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:bundles:size": "size-limit",
     "test:source": "npm run test:ts && npm t -- --coverage",
     "test:ts": "typings-tester --config ./src/types/__tests__/tsconfig.json --dir ./src/types/__tests__",
+    "test:update": "npm run compile && npm run test:bundles:snapshot -- -u",
     "clean": "rm -rf lib es dist",
     "compile": "npm run clean && rollup -c",
     "contrib:add": "all-contributors add",

--- a/src/ReactMinimalPieChartLabel.js
+++ b/src/ReactMinimalPieChartLabel.js
@@ -11,7 +11,7 @@ export default function ReactMinimalPieChartLabel({
   return (
     <text
       textAnchor="middle"
-      alignmentBaseline="middle"
+      dominantBaseline="middle"
       fill={color}
       {...props}
     />


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

`alignment-baseline` [doesn't work as expected](https://stackoverflow.com/questions/19212498/firefox-support-for-alignment-baseline-property) on Firefox.

### What is the new behaviour?

Add `dominant-baseline` property in addition to the existing `alignment-baseline`.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes, if the user relies on `labelStyle` prop to override default  `alignment-baseline`.

### Other information:
#67 

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
