### PR TITLE
Make reveal prop work same direction as lengthAngle

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -137,8 +137,9 @@ exports[`Dist bundle is unchanged 1`] = `
     // https://css-tricks.com/svg-line-animation-works/
 
     if (typeof reveal === 'number') {
-      strokeDasharray = degreesToRadians(actualRadio) * Math.abs(lengthAngle);
-      strokeDashoffset = strokeDasharray + extractPercentage(strokeDasharray, reveal);
+      var pathLength = degreesToRadians(actualRadio) * lengthAngle;
+      strokeDasharray = Math.abs(pathLength);
+      strokeDashoffset = pathLength - extractPercentage(pathLength, reveal);
     }
 
     return React__default.createElement(\\"path\\", _extends({

--- a/src/ReactMinimalPieChartPath.js
+++ b/src/ReactMinimalPieChartPath.js
@@ -42,9 +42,9 @@ export default function ReactMinimalPieChartPath({
   // Animate/hide paths with "stroke-dasharray" + "stroke-dashoffset"
   // https://css-tricks.com/svg-line-animation-works/
   if (typeof reveal === 'number') {
-    strokeDasharray = degreesToRadians(actualRadio) * Math.abs(lengthAngle);
-    strokeDashoffset =
-      strokeDasharray + extractPercentage(strokeDasharray, reveal);
+    const pathLength = degreesToRadians(actualRadio) * lengthAngle;
+    strokeDasharray = Math.abs(pathLength);
+    strokeDashoffset = pathLength - extractPercentage(pathLength, reveal);
   }
 
   return (

--- a/src/__tests__/ReactMinimalPieChartPath.js
+++ b/src/__tests__/ReactMinimalPieChartPath.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import PieChartPath from '../ReactMinimalPieChartPath';
+import { degreesToRadians } from '../utils';
 
 describe('ReactMinimalPieChartPath component', () => {
   it('Should return a "path" element with defined "d" prop', () => {
@@ -12,38 +13,49 @@ describe('ReactMinimalPieChartPath component', () => {
 
   it('Should render a path with "strokeWidth" = 5', () => {
     const wrapper = shallow(<PieChartPath cx={100} cy={100} lineWidth={5} />);
-
     expect(wrapper.prop('strokeWidth')).toBe(5);
   });
 
-  it('Should render a fully revealed path with "strokeDashoffset" === 2 x "strokeDasharray"', () => {
-    const wrapper = shallow(
-      <PieChartPath cx={100} cy={100} lengthAngle={360} reveal={100} />
-    );
+  describe('reveal', () => {
+    const pathLength = degreesToRadians(50) * 360;
 
-    expect(wrapper.prop('strokeDashoffset')).toBe(
-      wrapper.prop('strokeDasharray') * 2
-    );
-  });
+    describe('100', () => {
+      it('Renders a fully revealed path with "strokeDasharray" === path length & "strokeDashoffset" === 0', () => {
+        const wrapper = shallow(
+          <PieChartPath
+            cx={100}
+            cy={100}
+            lengthAngle={360}
+            radius={100}
+            reveal={100}
+          />
+        );
 
-  it('Should render a fully hidden path with "strokeDashoffset" === "strokeDasharray"', () => {
-    const wrapper = shallow(
-      <PieChartPath cx={100} cy={100} lengthAngle={360} reveal={0} />
-    );
+        expect(wrapper.prop('strokeDasharray')).toBe(pathLength);
+        expect(wrapper.prop('strokeDashoffset')).toBe(0);
+      });
+    });
 
-    expect(wrapper.prop('strokeDashoffset') > 0).toBe(true);
-    expect(wrapper.prop('strokeDashoffset')).toEqual(
-      wrapper.prop('strokeDasharray')
-    );
-  });
+    describe('0', () => {
+      it('Renders a fully hidden path with "strokeDashoffset" === "strokeDasharray"', () => {
+        const wrapper = shallow(
+          <PieChartPath cx={100} cy={100} lengthAngle={360} reveal={0} />
+        );
 
-  it('Should render a partially hidden path (1/4) with "strokeDashoffset"/"strokeDasharray"', () => {
-    const wrapper = shallow(
-      <PieChartPath cx={100} cy={100} lengthAngle={360} reveal={25} />
-    );
+        expect(wrapper.prop('strokeDasharray')).toBe(pathLength);
+        expect(wrapper.prop('strokeDashoffset')).toBe(pathLength);
+      });
+    });
 
-    const strokeDashoffset = wrapper.prop('strokeDashoffset');
-    const strokeDasharray = wrapper.prop('strokeDasharray');
-    expect(strokeDashoffset).toEqual(strokeDasharray + strokeDasharray / 4);
+    describe('with negative "lengthAngle"', () => {
+      it('Renders a path with negative "strokeDashoffset"', () => {
+        const wrapper = shallow(
+          <PieChartPath cx={100} cy={100} lengthAngle={-360} reveal={0} />
+        );
+
+        expect(wrapper.prop('strokeDasharray')).toBe(pathLength);
+        expect(wrapper.prop('strokeDashoffset')).toBe(-pathLength);
+      });
+    });
   });
 });


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

`reveal` prop reveals path in the opposite direction of `lengthAngle` prop

### What is the new behaviour?

Make `reveal` go same direction as `lengthAngle`.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes. `reveal` property will reveal the chart path using the opposite direction then before. Same goes for animations direction.

### Other information:
#53 

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
