### PR TITLE
Fix reveal with negative lengthAngle

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -139,7 +139,7 @@ exports[`Dist bundle is unchanged 1`] = `
     if (typeof reveal === 'number') {
       var pathLength = degreesToRadians(actualRadio) * lengthAngle;
       strokeDasharray = Math.abs(pathLength);
-      strokeDashoffset = pathLength - extractPercentage(pathLength, reveal);
+      strokeDashoffset = strokeDasharray - extractPercentage(strokeDasharray, reveal);
     }
 
     return React__default.createElement(\\"path\\", _extends({

--- a/src/ReactMinimalPieChartPath.js
+++ b/src/ReactMinimalPieChartPath.js
@@ -44,7 +44,8 @@ export default function ReactMinimalPieChartPath({
   if (typeof reveal === 'number') {
     const pathLength = degreesToRadians(actualRadio) * lengthAngle;
     strokeDasharray = Math.abs(pathLength);
-    strokeDashoffset = pathLength - extractPercentage(pathLength, reveal);
+    strokeDashoffset =
+      strokeDasharray - extractPercentage(strokeDasharray, reveal);
   }
 
   return (

--- a/src/__tests__/ReactMinimalPieChartPath.js
+++ b/src/__tests__/ReactMinimalPieChartPath.js
@@ -45,16 +45,16 @@ describe('ReactMinimalPieChartPath component', () => {
         expect(wrapper.prop('strokeDasharray')).toBe(pathLength);
         expect(wrapper.prop('strokeDashoffset')).toBe(pathLength);
       });
-    });
 
-    describe('with negative "lengthAngle"', () => {
-      it('Renders a path with negative "strokeDashoffset"', () => {
-        const wrapper = shallow(
-          <PieChartPath cx={100} cy={100} lengthAngle={-360} reveal={0} />
-        );
+      describe('with negative "lengthAngle"', () => {
+        it('Renders same "strokeDashoffset" value', () => {
+          const wrapper = shallow(
+            <PieChartPath cx={100} cy={100} lengthAngle={-360} reveal={0} />
+          );
 
-        expect(wrapper.prop('strokeDasharray')).toBe(pathLength);
-        expect(wrapper.prop('strokeDashoffset')).toBe(-pathLength);
+          expect(wrapper.prop('strokeDasharray')).toBe(pathLength);
+          expect(wrapper.prop('strokeDashoffset')).toBe(pathLength);
+        });
       });
     });
   });


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

`reveal` doesn't reverse animation direction when `lengthAngle` is negative

### What is the new behaviour?

`reveal` animation direction follows `lengthAngle`.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes, but previous behaviour was a bug.

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
