### PR TITLE
Remove stroke properties after initial animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Sizes in the third column are calculated with a "real-world" setup: see [source 
 - Make a device/browser compatibility table
 - Consider moving storybook deployment to CI
 - Configure Babel to not inject the `_extend` utility in compiled artifact
+- Cleanup animation stroke properties for non-initial animations
 
 ## Contributors
 

--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -49,6 +49,14 @@ exports[`Dist bundle is unchanged 1`] = `
     return target;
   }
 
+  function _assertThisInitialized(self) {
+    if (self === void 0) {
+      throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\");
+    }
+
+    return self;
+  }
+
   var partialCircle = function partialCircle(cx, cy, r, start, end) {
     var length = end - start;
     if (length === 0) return [];
@@ -289,22 +297,13 @@ exports[`Dist bundle is unchanged 1`] = `
     });
   }
 
-  function renderSegments(data, props, hide) {
+  function renderSegments(data, props, forcedReveal, animationEndCallback) {
     var style = props.segmentsStyle;
-    var reveal;
+    var reveal = forcedReveal === undefined ? props.reveal : forcedReveal;
 
     if (props.animate) {
       var transitionStyle = makeSegmentTransitionStyle(props.animationDuration, props.animationEasing, style);
       style = Object.assign({}, style, transitionStyle);
-    } // Hide/reveal the segment?
-
-
-    if (hide === true) {
-      reveal = 0;
-    } else if (typeof props.reveal === 'number') {
-      reveal = props.reveal;
-    } else if (hide === false) {
-      reveal = 100;
     }
 
     var paths = data.map(function (dataEntry, index) {
@@ -331,7 +330,8 @@ exports[`Dist bundle is unchanged 1`] = `
         },
         onClick: props.onClick && function (e) {
           return props.onClick(e, props.data, index);
-        }
+        },
+        onTransitionEnd: index === 0 ? animationEndCallback : undefined
       });
     });
 
@@ -362,8 +362,10 @@ exports[`Dist bundle is unchanged 1`] = `
       var _this;
 
       _this = _Component.call(this, props) || this;
+      _this.clearAnimation = _this.clearAnimation.bind(_assertThisInitialized(_this));
 
       if (_this.props.animate === true) {
+        _this.initialAnimationPending = true;
         _this.hideSegments = true;
       }
 
@@ -376,10 +378,10 @@ exports[`Dist bundle is unchanged 1`] = `
       var _this2 = this;
 
       if (this.props.animate === true && requestAnimationFrame) {
-        this.initialAnimationTimerId = setTimeout(function () {
-          _this2.initialAnimationTimerId = null;
-          _this2.initialAnimationRAFId = requestAnimationFrame(function () {
-            _this2.initialAnimationRAFId = null;
+        this.animationTimerId = setTimeout(function () {
+          _this2.animationTimerId = null;
+          _this2.animationRAFId = requestAnimationFrame(function () {
+            _this2.animationRAFId = null;
 
             _this2.startAnimation();
           });
@@ -388,12 +390,20 @@ exports[`Dist bundle is unchanged 1`] = `
     };
 
     _proto.componentWillUnmount = function componentWillUnmount() {
-      if (this.initialAnimationTimerId) {
-        clearTimeout(this.initialAnimationTimerId);
+      if (this.animationTimerId) {
+        clearTimeout(this.animationTimerId);
       }
 
-      if (this.initialAnimationRAFId) {
-        cancelAnimationFrame(this.initialAnimationRAFId);
+      if (this.animationRAFId) {
+        cancelAnimationFrame(this.animationRAFId);
+      }
+    };
+
+    _proto.evaluateForcedReveal = function evaluateForcedReveal() {
+      if (this.initialAnimationPending) {
+        var reveal = this.props.reveal;
+        var animateRevealTo = reveal !== undefined ? reveal : 100;
+        return this.hideSegments ? 0 : animateRevealTo;
       }
     };
 
@@ -402,23 +412,30 @@ exports[`Dist bundle is unchanged 1`] = `
       this.forceUpdate();
     };
 
+    _proto.clearAnimation = function clearAnimation() {
+      this.initialAnimationPending = false;
+      this.forceUpdate();
+    };
+
     _proto.render = function render() {
-      if (this.props.data === undefined) {
+      var props = this.props;
+
+      if (props.data === undefined) {
         return null;
       }
 
-      var extendedData = extendData(this.props);
+      var extendedData = extendData(props);
       return React__default.createElement(\\"div\\", {
-        className: this.props.className,
-        style: this.props.style
+        className: props.className,
+        style: props.style
       }, React__default.createElement(\\"svg\\", {
-        viewBox: evaluateViewBoxSize(this.props.ratio, VIEWBOX_SIZE),
+        viewBox: evaluateViewBoxSize(props.ratio, VIEWBOX_SIZE),
         width: \\"100%\\",
         height: \\"100%\\",
         style: {
           display: 'block'
         }
-      }, renderSegments(extendedData, this.props, this.hideSegments), this.props.label && renderLabels(extendedData, this.props), this.props.injectSvg && this.props.injectSvg()), this.props.children);
+      }, renderSegments(extendedData, props, this.evaluateForcedReveal(), props.animate ? this.clearAnimation : undefined), props.label && renderLabels(extendedData, props), props.injectSvg && props.injectSvg()), props.children);
     };
 
     return ReactMinimalPieChart;

--- a/src/__tests__/Chart.js
+++ b/src/__tests__/Chart.js
@@ -229,17 +229,50 @@ describe('ReactMinimalPieChart', () => {
       });
     });
 
-    it('re-renders on did mount updating segments\' "reveal" prop from 0 to 100', () => {
-      const wrapper = render({
-        animate: true,
+    describe('Initial animation cycle', () => {
+      it(`- 1st render: force segments' "reveal" to 0
+          - 2nd render (didMount): (didMount) force segments\' "reveal" to 100
+          - 3nd render (after initial animation - onTransitionEnd): reset "reveal" to undefined'
+        `, () => {
+        const wrapper = render({
+          animate: true,
+        });
+        let firstPath = wrapper.find('ReactMinimalPieChartPath').first();
+        expect(firstPath.prop('reveal')).toEqual(0);
+
+        jest.runAllTimers();
+
+        firstPath = wrapper.find('ReactMinimalPieChartPath').first();
+        expect(firstPath.prop('reveal')).toEqual(100);
+
+        firstPath.simulate('transitionEnd');
+        firstPath = wrapper.find('ReactMinimalPieChartPath').first();
+        expect(firstPath.prop('reveal')).toBe(undefined);
       });
-      let firstPath = wrapper.find('ReactMinimalPieChartPath').first();
-      expect(firstPath.prop('reveal')).toEqual(0);
 
-      jest.runAllTimers();
+      describe('with reveal', () => {
+        it(`
+        - 1st render: force segments' "reveal" to 0
+        - 2nd render (didMount): render segments\' with provided reveal prop
+        - 3nd render (after initial animation - onTransitionEnd): no changes'
+      `, () => {
+          const wrapper = render({
+            animate: true,
+            reveal: 50,
+          });
+          let firstPath = wrapper.find('ReactMinimalPieChartPath').first();
+          expect(firstPath.prop('reveal')).toEqual(0);
 
-      firstPath = wrapper.find('ReactMinimalPieChartPath').first();
-      expect(firstPath.prop('reveal')).toEqual(100);
+          jest.runAllTimers();
+
+          firstPath = wrapper.find('ReactMinimalPieChartPath').first();
+          expect(firstPath.prop('reveal')).toEqual(50);
+
+          firstPath.simulate('transitionEnd');
+          firstPath = wrapper.find('ReactMinimalPieChartPath').first();
+          expect(firstPath.prop('reveal')).toEqual(50);
+        });
+      });
     });
 
     it('does not re-render when component is unmounted', () => {


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_
`stroke-dasharray` and `stroke-dashoffset` stay rendered after initial animation even when not needed. 

### What is the new behaviour?

Remove `stroke-dasharray` and `stroke-dashoffset` after initial animation.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
