### PR TITLE
Fix error on console when totalValue equals zero

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -218,7 +218,7 @@ exports[`Dist bundle is unchanged 1`] = `
     var degreesTakenByPaths = normalizedTotalAngle - degreesTakenByPadding;
     var lastSegmentEnd = 0;
     return data.map(function (dataEntry) {
-      var valueInPercentage = dataEntry.value / total * 100;
+      var valueInPercentage = dataEntry.value / (total || 1) * 100;
       var degrees = extractPercentage(degreesTakenByPaths, valueInPercentage);
       var startOffset = lastSegmentEnd;
       lastSegmentEnd = lastSegmentEnd + degrees + singlePaddingDegrees;

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -35,7 +35,7 @@ function extendData({
   let lastSegmentEnd = 0;
 
   return data.map(dataEntry => {
-    const valueInPercentage = (dataEntry.value / total) * 100;
+    const valueInPercentage = (dataEntry.value / (total || 1)) * 100;
     const degrees = extractPercentage(degreesTakenByPaths, valueInPercentage);
     const startOffset = lastSegmentEnd;
     lastSegmentEnd = lastSegmentEnd + degrees + singlePaddingDegrees;


### PR DESCRIPTION
### What kind of change does this PR introduce? 
Fix error on console when totalValue is 0, and sum of all Values is 0.
This does not have any visual impact.

### What is the current behaviour? _(You can also link to an open issue here)_
![react-minimal-error](https://user-images.githubusercontent.com/5117006/66087302-a0cb7e80-e53c-11e9-9a91-cba970c2041c.png)

### What is the new behaviour?
No error in the console.
Visually is the same result.

### Does this PR introduce a breaking change? 
Nope

### Other information:

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [-] Docs have been added / updated
