### PR TITLE
Introduce custom viewBoxSize prop

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -114,7 +114,18 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "damien-git",
+      "name": "damien-git",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/7503971?v=4",
+      "profile": "https://github.com/damien-git",
+      "contributions": [
+        "bug",
+        "ideas"
+      ]
     }
   ],
-  "repoType": "github"
+  "repoType": "github",
+  "commitConvention": "none"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.0.0
+
+### Breaking Changes
+
+- `ratio` property removed in favour of `viewBoxSize`
+
 # 5.0.2
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Because [Recharts][recharts-github] is awesome, but when you just need a simple 
 | **data** _(required)_ | _Array_                               | The source data which each element is a segment.                                                                                                                                             | -          |
 | **cx**                | _Number_                              | The x-coordinate of center. The value is the percentage of the component width                                                                                                               | 50         |
 | **cy**                | _Number_                              | The y-coordinate of center. The value is the percentage of the component height                                                                                                              | 50         |
-| **ratio**             | _Number_                              | The ratio of rendered svg element                                                                                                                                                            | 1          |
+| **viewBoxSize**       | _Array of Numbers_                    | Width and Height of SVG `viewBox` attribute                                                                                                                                                  | [100, 100] |
 | **startAngle**        | _Number_                              | The start angle of first sector                                                                                                                                                              | 0          |
 | **lengthAngle**       | _Number_                              | The total angle taken by the chart _(can be negative to make the chart clockwise!)_                                                                                                          | 360        |
 | **totalValue**        | _Number_                              | The total value represented by the full chart                                                                                                                                                | -          |
@@ -79,11 +79,11 @@ Because [Recharts][recharts-github] is awesome, but when you just need a simple 
 
 ```typescript
 type dataProps = {
-  value: number,
-  color: string,
-  title?: string | number,
-  key?: string | number,
-  style?: {[key: string]: string | number},
+  value: number;
+  color: string;
+  title?: string | number;
+  key?: string | number;
+  style?: { [key: string]: string | number };
 }[];
 ```
 
@@ -98,21 +98,21 @@ When `label` is a **function** or **ReactElement**, the provided entity will be 
 
 ```typescript
 type labelProps = {
-  key: string,
-  x: number,
-  y: number,
-  dx: number,
-  dy: number,
-  textAnchor: string,
+  key: string;
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  textAnchor: string;
   data: {
     // props.data entry extended with:
-    degrees: number,
-    startOffset: number,
-    percentage: number,
-  }[],
-  dataIndex: number,
-  color: string,
-  style: {[key: string]: string | number},
+    degrees: number;
+    startOffset: number;
+    percentage: number;
+  }[];
+  dataIndex: number;
+  color: string;
+  style: { [key: string]: string | number };
 };
 ```
 
@@ -182,8 +182,29 @@ Sizes in the third column are calculated with a "real-world" setup: see [source 
 Thanks to you all ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore -->
-<table><tr><td align="center"><a href="http://www.andreacarraro.it"><img src="https://avatars3.githubusercontent.com/u/4573549?v=4" width="100px;" alt="Andrea Carraro"/><br /><sub><b>Andrea Carraro</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=toomuchdesign" title="Code">💻</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=toomuchdesign" title="Documentation">📖</a> <a href="#infra-toomuchdesign" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=toomuchdesign" title="Tests">⚠️</a> <a href="#review-toomuchdesign" title="Reviewed Pull Requests">👀</a></td><td align="center"><a href="https://github.com/rufman"><img src="https://avatars3.githubusercontent.com/u/1128559?v=4" width="100px;" alt="Stephane Rufer"/><br /><sub><b>Stephane Rufer</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Arufman" title="Bug reports">🐛</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=rufman" title="Code">💻</a></td><td align="center"><a href="https://github.com/jaaberg"><img src="https://avatars3.githubusercontent.com/u/1413255?v=4" width="100px;" alt="Jørgen Aaberg"/><br /><sub><b>Jørgen Aaberg</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=jaaberg" title="Code">💻</a></td><td align="center"><a href="http://www.tobiahrex.com"><img src="https://avatars3.githubusercontent.com/u/16377119?v=4" width="100px;" alt="Tobiah Rex"/><br /><sub><b>Tobiah Rex</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3ATobiahRex" title="Bug reports">🐛</a></td><td align="center"><a href="https://edwardxiao.com"><img src="https://avatars2.githubusercontent.com/u/11728228?v=4" width="100px;" alt="Edward Xiao"/><br /><sub><b>Edward Xiao</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Aedwardfhsiao" title="Bug reports">🐛</a></td><td align="center"><a href="https://keybase.io/konsumer"><img src="https://avatars1.githubusercontent.com/u/83857?v=4" width="100px;" alt="David Konsumer"/><br /><sub><b>David Konsumer</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=konsumer" title="Code">💻</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=konsumer" title="Documentation">📖</a> <a href="#example-konsumer" title="Examples">💡</a> <a href="#ideas-konsumer" title="Ideas, Planning, & Feedback">🤔</a></td><td align="center"><a href="https://github.com/nehoraigold"><img src="https://avatars2.githubusercontent.com/u/44398222?v=4" width="100px;" alt="Ori"/><br /><sub><b>Ori</b></sub></a><br /><a href="#ideas-nehoraigold" title="Ideas, Planning, & Feedback">🤔</a></td></tr><tr><td align="center"><a href="https://www.manos.im/"><img src="https://avatars3.githubusercontent.com/u/6333409?v=4" width="100px;" alt="Emmanouil Konstantinidis"/><br /><sub><b>Emmanouil Konstantinidis</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Amanosim" title="Bug reports">🐛</a></td><td align="center"><a href="https://github.com/yuruc"><img src="https://avatars0.githubusercontent.com/u/5884342?v=4" width="100px;" alt="yuruc"/><br /><sub><b>yuruc</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=yuruc" title="Code">💻</a></td><td align="center"><a href="https://www.linkedin.com/in/luca-schiavone-7270a8138/"><img src="https://avatars1.githubusercontent.com/u/16616566?v=4" width="100px;" alt="luca-esse "/><br /><sub><b>luca-esse </b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Aluca-esse" title="Bug reports">🐛</a></td><td align="center"><a href="http://twitter.com/Osuka42"><img src="https://avatars1.githubusercontent.com/u/5117006?v=4" width="100px;" alt="Oscar Mendoza"/><br /><sub><b>Oscar Mendoza</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3AOsuka42g" title="Bug reports">🐛</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=Osuka42g" title="Code">💻</a></td></tr></table>
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="http://www.andreacarraro.it"><img src="https://avatars3.githubusercontent.com/u/4573549?v=4" width="100px;" alt="Andrea Carraro"/><br /><sub><b>Andrea Carraro</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=toomuchdesign" title="Code">💻</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=toomuchdesign" title="Documentation">📖</a> <a href="#infra-toomuchdesign" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=toomuchdesign" title="Tests">⚠️</a> <a href="#review-toomuchdesign" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://github.com/rufman"><img src="https://avatars3.githubusercontent.com/u/1128559?v=4" width="100px;" alt="Stephane Rufer"/><br /><sub><b>Stephane Rufer</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Arufman" title="Bug reports">🐛</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=rufman" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jaaberg"><img src="https://avatars3.githubusercontent.com/u/1413255?v=4" width="100px;" alt="Jørgen Aaberg"/><br /><sub><b>Jørgen Aaberg</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=jaaberg" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.tobiahrex.com"><img src="https://avatars3.githubusercontent.com/u/16377119?v=4" width="100px;" alt="Tobiah Rex"/><br /><sub><b>Tobiah Rex</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3ATobiahRex" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://edwardxiao.com"><img src="https://avatars2.githubusercontent.com/u/11728228?v=4" width="100px;" alt="Edward Xiao"/><br /><sub><b>Edward Xiao</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Aedwardfhsiao" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://keybase.io/konsumer"><img src="https://avatars1.githubusercontent.com/u/83857?v=4" width="100px;" alt="David Konsumer"/><br /><sub><b>David Konsumer</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=konsumer" title="Code">💻</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=konsumer" title="Documentation">📖</a> <a href="#example-konsumer" title="Examples">💡</a> <a href="#ideas-konsumer" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/nehoraigold"><img src="https://avatars2.githubusercontent.com/u/44398222?v=4" width="100px;" alt="Ori"/><br /><sub><b>Ori</b></sub></a><br /><a href="#ideas-nehoraigold" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://www.manos.im/"><img src="https://avatars3.githubusercontent.com/u/6333409?v=4" width="100px;" alt="Emmanouil Konstantinidis"/><br /><sub><b>Emmanouil Konstantinidis</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Amanosim" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://github.com/yuruc"><img src="https://avatars0.githubusercontent.com/u/5884342?v=4" width="100px;" alt="yuruc"/><br /><sub><b>yuruc</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=yuruc" title="Code">💻</a></td>
+    <td align="center"><a href="https://www.linkedin.com/in/luca-schiavone-7270a8138/"><img src="https://avatars1.githubusercontent.com/u/16616566?v=4" width="100px;" alt="luca-esse "/><br /><sub><b>luca-esse </b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Aluca-esse" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="http://twitter.com/Osuka42"><img src="https://avatars1.githubusercontent.com/u/5117006?v=4" width="100px;" alt="Oscar Mendoza"/><br /><sub><b>Oscar Mendoza</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3AOsuka42g" title="Bug reports">🐛</a> <a href="https://github.com/toomuchdesign/react-minimal-pie-chart/commits?author=Osuka42g" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/damien-git"><img src="https://avatars0.githubusercontent.com/u/7503971?v=4" width="100px;" alt="damien-git"/><br /><sub><b>damien-git</b></sub></a><br /><a href="https://github.com/toomuchdesign/react-minimal-pie-chart/issues?q=author%3Adamien-git" title="Bug reports">🐛</a> <a href="#ideas-damien-git" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -67,15 +67,6 @@ exports[`Dist bundle is unchanged 1`] = `
   function degreesToRadians(degrees) {
     return degrees * PI / 180;
   }
-  function evaluateViewBoxSize(ratio, baseSize) {
-    // Wide ratio
-    if (ratio > 1) {
-      return \\"0 0 \\" + baseSize + \\" \\" + baseSize / ratio;
-    } // Narrow/squared ratio
-
-
-    return \\"0 0 \\" + baseSize * ratio + \\" \\" + baseSize;
-  }
   function evaluateLabelTextAnchor(_temp) {
     var _ref = _temp === void 0 ? {} : _temp,
         labelPosition = _ref.labelPosition,
@@ -195,8 +186,14 @@ exports[`Dist bundle is unchanged 1`] = `
     color: PropTypes.string
   };
 
-  var VIEWBOX_SIZE = 100;
-  var VIEWBOX_HALF_SIZE = VIEWBOX_SIZE / 2;
+  function extractAbsoluteCoordinates(props) {
+    var viewBoxWidth = props.viewBoxSize[0];
+    return {
+      cx: extractPercentage(props.cx, viewBoxWidth),
+      cy: extractPercentage(props.cy, viewBoxWidth),
+      radius: extractPercentage(props.radius, viewBoxWidth)
+    };
+  }
 
   function sumValues(data) {
     return data.reduce(function (acc, dataEntry) {
@@ -262,7 +259,12 @@ exports[`Dist bundle is unchanged 1`] = `
   }
 
   function renderLabels(data, props) {
-    var labelPosition = extractPercentage(props.radius, props.labelPosition);
+    var _extractAbsoluteCoord = extractAbsoluteCoordinates(props),
+        cx = _extractAbsoluteCoord.cx,
+        cy = _extractAbsoluteCoord.cy,
+        radius = _extractAbsoluteCoord.radius;
+
+    var labelPosition = extractPercentage(radius, props.labelPosition);
     return data.map(function (dataEntry, index) {
       var startAngle = props.startAngle + dataEntry.startOffset;
       var halfAngle = startAngle + dataEntry.degrees / 2;
@@ -272,8 +274,8 @@ exports[`Dist bundle is unchanged 1`] = `
 
       var labelProps = {
         key: \\"label-\\" + (dataEntry.key || index),
-        x: props.cx,
-        y: props.cy,
+        x: cx,
+        y: cy,
         dx: dx,
         dy: dy,
         textAnchor: evaluateLabelTextAnchor({
@@ -292,13 +294,14 @@ exports[`Dist bundle is unchanged 1`] = `
 
   function renderSegments(data, props, hide) {
     var style = props.segmentsStyle;
-    var reveal;
 
     if (props.animate) {
       var transitionStyle = makeSegmentTransitionStyle(props.animationDuration, props.animationEasing, style);
       style = Object.assign({}, style, transitionStyle);
     } // Hide/reveal the segment?
 
+
+    var reveal;
 
     if (hide === true) {
       reveal = 0;
@@ -308,16 +311,22 @@ exports[`Dist bundle is unchanged 1`] = `
       reveal = 100;
     }
 
+    var _extractAbsoluteCoord2 = extractAbsoluteCoordinates(props),
+        cx = _extractAbsoluteCoord2.cx,
+        cy = _extractAbsoluteCoord2.cy,
+        radius = _extractAbsoluteCoord2.radius;
+
+    var lineWidth = extractPercentage(radius, props.lineWidth);
     var paths = data.map(function (dataEntry, index) {
       var startAngle = props.startAngle + dataEntry.startOffset;
       return React__default.createElement(ReactMinimalPieChartPath, {
         key: dataEntry.key || index,
-        cx: props.cx,
-        cy: props.cy,
+        cx: cx,
+        cy: cy,
         startAngle: startAngle,
         lengthAngle: dataEntry.degrees,
-        radius: props.radius,
-        lineWidth: extractPercentage(props.radius, props.lineWidth),
+        radius: radius,
+        lineWidth: lineWidth,
         reveal: reveal,
         title: dataEntry.title,
         style: Object.assign({}, style, dataEntry.style),
@@ -339,12 +348,12 @@ exports[`Dist bundle is unchanged 1`] = `
     if (props.background) {
       paths.unshift(React__default.createElement(ReactMinimalPieChartPath, {
         key: \\"bg\\",
-        cx: props.cx,
-        cy: props.cy,
+        cx: cx,
+        cy: cy,
         startAngle: props.startAngle,
         lengthAngle: props.lengthAngle,
-        radius: props.radius,
-        lineWidth: extractPercentage(props.radius, props.lineWidth),
+        radius: radius,
+        lineWidth: lineWidth,
         stroke: props.background,
         strokeLinecap: props.rounded ? 'round' : undefined,
         fill: \\"none\\"
@@ -413,7 +422,7 @@ exports[`Dist bundle is unchanged 1`] = `
         className: this.props.className,
         style: this.props.style
       }, React__default.createElement(\\"svg\\", {
-        viewBox: evaluateViewBoxSize(this.props.ratio, VIEWBOX_SIZE),
+        viewBox: \\"0 0 \\" + this.props.viewBoxSize[0] + \\" \\" + this.props.viewBoxSize[1],
         width: \\"100%\\",
         height: \\"100%\\",
         style: {
@@ -429,7 +438,7 @@ exports[`Dist bundle is unchanged 1`] = `
     data: dataPropType,
     cx: PropTypes.number,
     cy: PropTypes.number,
-    ratio: PropTypes.number,
+    viewBoxSize: PropTypes.arrayOf(PropTypes.number),
     totalValue: PropTypes.number,
     className: PropTypes.string,
     style: stylePropType,
@@ -455,14 +464,14 @@ exports[`Dist bundle is unchanged 1`] = `
     onClick: PropTypes.func
   };
   ReactMinimalPieChart.defaultProps = {
-    cx: VIEWBOX_HALF_SIZE,
-    cy: VIEWBOX_HALF_SIZE,
-    ratio: 1,
+    cx: 50,
+    cy: 50,
+    viewBoxSize: [100, 100],
     startAngle: 0,
     lengthAngle: 360,
     paddingAngle: 0,
     lineWidth: 100,
-    radius: VIEWBOX_HALF_SIZE,
+    radius: 50,
     rounded: false,
     animate: false,
     animationDuration: 500,

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -10,8 +10,14 @@ import {
   valueBetween,
 } from './utils';
 
-const VIEWBOX_SIZE = 100;
-const VIEWBOX_HALF_SIZE = VIEWBOX_SIZE / 2;
+function extractAbsoluteCoordinates(props) {
+  const viewBoxWidth = props.viewBoxSize[0];
+  return {
+    cx: extractPercentage(props.cx, viewBoxWidth),
+    cy: extractPercentage(props.cy, viewBoxWidth),
+    radius: extractPercentage(props.radius, viewBoxWidth),
+  };
+}
 
 function sumValues(data) {
   return data.reduce((acc, dataEntry) => acc + dataEntry.value, 0);
@@ -80,7 +86,8 @@ function renderLabelItem(option, props, value) {
 }
 
 function renderLabels(data, props) {
-  const labelPosition = extractPercentage(props.radius, props.labelPosition);
+  const { cx, cy, radius } = extractAbsoluteCoordinates(props);
+  const labelPosition = extractPercentage(radius, props.labelPosition);
 
   return data.map((dataEntry, index) => {
     const startAngle = props.startAngle + dataEntry.startOffset;
@@ -92,8 +99,8 @@ function renderLabels(data, props) {
     // This object is passed as props to the "label" component
     const labelProps = {
       key: `label-${dataEntry.key || index}`,
-      x: props.cx,
-      y: props.cy,
+      x: cx,
+      y: cy,
       dx,
       dy,
       textAnchor: evaluateLabelTextAnchor({
@@ -113,8 +120,6 @@ function renderLabels(data, props) {
 
 function renderSegments(data, props, hide) {
   let style = props.segmentsStyle;
-  let reveal;
-
   if (props.animate) {
     const transitionStyle = makeSegmentTransitionStyle(
       props.animationDuration,
@@ -125,6 +130,7 @@ function renderSegments(data, props, hide) {
   }
 
   // Hide/reveal the segment?
+  let reveal;
   if (hide === true) {
     reveal = 0;
   } else if (typeof props.reveal === 'number') {
@@ -133,18 +139,20 @@ function renderSegments(data, props, hide) {
     reveal = 100;
   }
 
+  const { cx, cy, radius } = extractAbsoluteCoordinates(props);
+  const lineWidth = extractPercentage(radius, props.lineWidth);
   const paths = data.map((dataEntry, index) => {
     const startAngle = props.startAngle + dataEntry.startOffset;
 
     return (
       <Path
         key={dataEntry.key || index}
-        cx={props.cx}
-        cy={props.cy}
+        cx={cx}
+        cy={cy}
         startAngle={startAngle}
         lengthAngle={dataEntry.degrees}
-        radius={props.radius}
-        lineWidth={extractPercentage(props.radius, props.lineWidth)}
+        radius={radius}
+        lineWidth={lineWidth}
         reveal={reveal}
         title={dataEntry.title}
         style={Object.assign({}, style, dataEntry.style)}
@@ -166,12 +174,12 @@ function renderSegments(data, props, hide) {
     paths.unshift(
       <Path
         key="bg"
-        cx={props.cx}
-        cy={props.cy}
+        cx={cx}
+        cy={cy}
         startAngle={props.startAngle}
         lengthAngle={props.lengthAngle}
-        radius={props.radius}
-        lineWidth={extractPercentage(props.radius, props.lineWidth)}
+        radius={radius}
+        lineWidth={lineWidth}
         stroke={props.background}
         strokeLinecap={props.rounded ? 'round' : undefined}
         fill="none"
@@ -280,14 +288,14 @@ ReactMinimalPieChart.propTypes = {
 };
 
 ReactMinimalPieChart.defaultProps = {
-  cx: VIEWBOX_HALF_SIZE,
-  cy: VIEWBOX_HALF_SIZE,
+  cx: 50,
+  cy: 50,
   viewBoxSize: [100, 100],
   startAngle: 0,
   lengthAngle: 360,
   paddingAngle: 0,
   lineWidth: 100,
-  radius: VIEWBOX_HALF_SIZE,
+  radius: 50,
   rounded: false,
   animate: false,
   animationDuration: 500,

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -5,7 +5,6 @@ import DefaultLabel from './Label';
 import { dataPropType, stylePropType } from './propTypes';
 import {
   degreesToRadians,
-  evaluateViewBoxSize,
   evaluateLabelTextAnchor,
   extractPercentage,
   valueBetween,
@@ -227,10 +226,9 @@ export default class ReactMinimalPieChart extends Component {
     return (
       <div className={this.props.className} style={this.props.style}>
         <svg
-          viewBox={evaluateViewBoxSize(
-            this.props.ratio,
-            this.props.viewBoxSize
-          )}
+          viewBox={`0 0 ${this.props.viewBoxSize[0]} ${
+            this.props.viewBoxSize[1]
+          }`}
           width="100%"
           height="100%"
           style={{ display: 'block' }}
@@ -252,7 +250,6 @@ ReactMinimalPieChart.propTypes = {
   cx: PropTypes.number,
   cy: PropTypes.number,
   viewBoxSize: PropTypes.arrayOf(PropTypes.number),
-  ratio: PropTypes.number,
   totalValue: PropTypes.number,
   className: PropTypes.string,
   style: stylePropType,
@@ -286,7 +283,6 @@ ReactMinimalPieChart.defaultProps = {
   cx: VIEWBOX_HALF_SIZE,
   cy: VIEWBOX_HALF_SIZE,
   viewBoxSize: [100, 100],
-  ratio: 1,
   startAngle: 0,
   lengthAngle: 360,
   paddingAngle: 0,

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -227,7 +227,10 @@ export default class ReactMinimalPieChart extends Component {
     return (
       <div className={this.props.className} style={this.props.style}>
         <svg
-          viewBox={evaluateViewBoxSize(this.props.ratio, VIEWBOX_SIZE)}
+          viewBox={evaluateViewBoxSize(
+            this.props.ratio,
+            this.props.viewBoxSize
+          )}
           width="100%"
           height="100%"
           style={{ display: 'block' }}
@@ -248,6 +251,7 @@ ReactMinimalPieChart.propTypes = {
   data: dataPropType,
   cx: PropTypes.number,
   cy: PropTypes.number,
+  viewBoxSize: PropTypes.arrayOf(PropTypes.number),
   ratio: PropTypes.number,
   totalValue: PropTypes.number,
   className: PropTypes.string,
@@ -281,6 +285,7 @@ ReactMinimalPieChart.propTypes = {
 ReactMinimalPieChart.defaultProps = {
   cx: VIEWBOX_HALF_SIZE,
   cy: VIEWBOX_HALF_SIZE,
+  viewBoxSize: [100, 100],
   ratio: 1,
   startAngle: 0,
   lengthAngle: 360,

--- a/src/__tests__/Chart.test.js
+++ b/src/__tests__/Chart.test.js
@@ -60,39 +60,26 @@ describe('Chart', () => {
     });
   });
 
-  describe('"ratio"', () => {
-    it('renders horizontal SVG element when > 1', () => {
-      const { container } = render({
-        ratio: 4,
-      });
-      const svg = container.querySelector('svg');
-      expect(svg).toHaveAttribute('viewBox', '0 0 100 25');
-    });
-
-    it('renders vertical SVG element when > 1', () => {
-      const { container } = render({
-        ratio: 1 / 10,
-      });
-      const svg = container.querySelector('svg');
-      expect(svg).toHaveAttribute('viewBox', '0 0 10 100');
-    });
-  });
-
   describe('"viewBoxSize"', () => {
-    test.each([[undefined, 100], [500, 500]])(
+    test.each([
+      [undefined, [100, 100]],
+      [[500, 500], [500, 500]],
+      [[500, 250], [500, 250]],
+    ])(
       'renders full-width chart in a SVG viewBox of given size',
-      (value, expectedViewBoxSize) => {
+      (value, expected) => {
+        const [expectedWidth, expectedHeight] = expected;
         const { container } = render({
           viewBoxSize: value,
         });
         const svg = container.querySelector('svg');
         expect(svg).toHaveAttribute(
           'viewBox',
-          `0 0 ${expectedViewBoxSize} ${expectedViewBoxSize}`
+          `0 0 ${expectedWidth} ${expectedHeight}`
         );
 
         const firstPath = container.querySelector('path');
-        expect(getArcInfo(firstPath).radius).toBe(expectedViewBoxSize / 4);
+        expect(getArcInfo(firstPath).radius).toBe(expectedWidth / 4);
       }
     );
   });

--- a/src/__tests__/Chart.test.js
+++ b/src/__tests__/Chart.test.js
@@ -60,8 +60,8 @@ describe('Chart', () => {
     });
   });
 
-  describe('<svg> element', () => {
-    it('is horizontal when "ratio" > 1', () => {
+  describe('"ratio"', () => {
+    it('renders horizontal SVG element when > 1', () => {
       const { container } = render({
         ratio: 4,
       });
@@ -69,13 +69,32 @@ describe('Chart', () => {
       expect(svg).toHaveAttribute('viewBox', '0 0 100 25');
     });
 
-    it('is vertical when "ratio" < 1', () => {
+    it('renders vertical SVG element when > 1', () => {
       const { container } = render({
         ratio: 1 / 10,
       });
       const svg = container.querySelector('svg');
       expect(svg).toHaveAttribute('viewBox', '0 0 10 100');
     });
+  });
+
+  describe('"viewBoxSize"', () => {
+    test.each([[undefined, 100], [500, 500]])(
+      'renders full-width chart in a SVG viewBox of given size',
+      (value, expectedViewBoxSize) => {
+        const { container } = render({
+          viewBoxSize: value,
+        });
+        const svg = container.querySelector('svg');
+        expect(svg).toHaveAttribute(
+          'viewBox',
+          `0 0 ${expectedViewBoxSize} ${expectedViewBoxSize}`
+        );
+
+        const firstPath = container.querySelector('path');
+        expect(getArcInfo(firstPath).radius).toBe(expectedViewBoxSize / 4);
+      }
+    );
   });
 
   describe('Partial circle', () => {
@@ -138,7 +157,7 @@ describe('Chart', () => {
 
       expect(backgroundInfo.startAngle).toBe(0);
       expect(backgroundInfo.lengthAngle).toBe(200);
-      expect(backgroundInfo.radio).toEqual(segmentInfo.radio);
+      expect(backgroundInfo.radius).toEqual(segmentInfo.radius);
       expect(background).toHaveAttribute('fill', 'none');
       expect(background).toHaveAttribute('stroke', 'green');
       expect(background).toHaveAttribute(

--- a/src/types/__tests__/test.ts
+++ b/src/types/__tests__/test.ts
@@ -94,7 +94,7 @@ function testPieChart() {
     data: dataMock,
     cx: 10,
     cy: 10,
-    ratio: 1,
+    viewBoxSize: [10, 10],
     startAngle: 90,
     lengthAngle: 200,
     totalValue: 30,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -50,7 +50,7 @@ declare type ChartProps = {
   data: PieChartData[];
   cx?: number;
   cy?: number;
-  ratio?: number;
+  viewBoxSize?: [number, number];
   startAngle?: number;
   lengthAngle?: number;
   totalValue?: number;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,15 +4,6 @@ export function degreesToRadians(degrees) {
   return (degrees * PI) / 180;
 }
 
-export function evaluateViewBoxSize(ratio, baseSize) {
-  // Wide ratio
-  if (ratio > 1) {
-    return `0 0 ${baseSize} ${baseSize / ratio}`;
-  }
-  // Narrow/squared ratio
-  return `0 0 ${baseSize * ratio} ${baseSize}`;
-}
-
 export function evaluateLabelTextAnchor({
   labelPosition,
   lineWidth,

--- a/stories/index.js
+++ b/stories/index.js
@@ -41,7 +41,12 @@ storiesOf('Loading indicator', module)
 
 storiesOf('Partial chart', module)
   .add('180° chart', () => (
-    <PieChart data={dataMock} startAngle={180} lengthAngle={180} ratio={2} />
+    <PieChart
+      data={dataMock}
+      startAngle={180}
+      lengthAngle={180}
+      viewBoxSize={[100, 50]}
+    />
   ))
   .add('90° chart', () => (
     <PieChart


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

See #106 

### What is the new behaviour?

Add property to customise SVG `viewBox` attribute width/height.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

YES. `ratio` property is removed and replaced with `viewBox`.

In order to change the chart ratio provide an explicit `viewBoxSize` value (it defaults at `[100, 100]`).

```diff
- ratio: 2
+ viewBoxSize: [100, 50]
```

### Other information:

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
