### PR TITLE
Fix: evaluate SVG cy value based on viewBoxSize height

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -187,10 +187,12 @@ exports[`Dist bundle is unchanged 1`] = `
   };
 
   function extractAbsoluteCoordinates(props) {
-    var viewBoxWidth = props.viewBoxSize[0];
+    var _props$viewBoxSize = props.viewBoxSize,
+        viewBoxWidth = _props$viewBoxSize[0],
+        viewBoxHeight = _props$viewBoxSize[1];
     return {
       cx: extractPercentage(props.cx, viewBoxWidth),
-      cy: extractPercentage(props.cy, viewBoxWidth),
+      cy: extractPercentage(props.cy, viewBoxHeight),
       radius: extractPercentage(props.radius, viewBoxWidth)
     };
   }

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -11,10 +11,10 @@ import {
 } from './utils';
 
 function extractAbsoluteCoordinates(props) {
-  const viewBoxWidth = props.viewBoxSize[0];
+  const [viewBoxWidth, viewBoxHeight] = props.viewBoxSize;
   return {
     cx: extractPercentage(props.cx, viewBoxWidth),
-    cy: extractPercentage(props.cy, viewBoxWidth),
+    cy: extractPercentage(props.cy, viewBoxHeight),
     radius: extractPercentage(props.radius, viewBoxWidth),
   };
 }

--- a/src/__tests__/Chart.test.js
+++ b/src/__tests__/Chart.test.js
@@ -67,10 +67,10 @@ describe('Chart', () => {
       [[500, 250], [500, 250]],
     ])(
       'renders full-width chart in a SVG viewBox of given size',
-      (value, expected) => {
+      (viewBoxSize, expected) => {
         const [expectedWidth, expectedHeight] = expected;
         const { container } = render({
-          viewBoxSize: value,
+          viewBoxSize,
         });
         const svg = container.querySelector('svg');
         expect(svg).toHaveAttribute(
@@ -79,7 +79,9 @@ describe('Chart', () => {
         );
 
         const firstPath = container.querySelector('path');
-        expect(getArcInfo(firstPath).radius).toBe(expectedWidth / 4);
+        const firstPathInfo = getArcInfo(firstPath);
+        expect(firstPathInfo.radius).toBe(expectedWidth / 4);
+        expect(firstPathInfo.startPoint.y).toBe(expectedHeight / 2);
       }
     );
   });

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -12,6 +12,7 @@ export function getArcInfo(element) {
 
 export function getArcPathInfo(d) {
   const [moveto, arc] = parseSVG(d);
+
   if (arc.rx !== arc.ry) {
     throw new Error('Provided path is not the section of a circumference');
   }
@@ -27,6 +28,10 @@ export function getArcPathInfo(d) {
   }
 
   return {
+    startPoint: {
+      x: moveto.x,
+      y: moveto.y,
+    },
     startAngle: getDegrees(CENTER, moveto),
     lengthAngle: degrees,
     radius: arc.rx,


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

`cy` evaluated from `viewBoxSize` width instead of height. https://github.com/toomuchdesign/react-minimal-pie-chart/issues/106#issuecomment-562162207

### What is the new behaviour?

evaluate `cy` from `viewBoxSize` height. 

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes, but the previous behaviour was wrong.

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
