### PR TITLE
Make Path component types stricter

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -315,17 +315,17 @@ exports[`Dist bundle is unchanged 1`] = `
         stroke: dataEntry.color,
         strokeLinecap: props.rounded ? 'round' : undefined,
         fill: \\"none\\",
-        onMouseOver: props.onMouseOver && // @ts-ignore
-        function (e) {
-          return props.onMouseOver(e, props.data, index);
+        onMouseOver: props.onMouseOver && function (e) {
+          // @ts-ignore
+          props.onMouseOver(e, props.data, index);
         },
-        onMouseOut: props.onMouseOut && // @ts-ignore
-        function (e) {
-          return props.onMouseOut(e, props.data, index);
+        onMouseOut: props.onMouseOut && function (e) {
+          // @ts-ignore
+          props.onMouseOut(e, props.data, index);
         },
-        onClick: props.onClick && // @ts-ignore
-        function (e) {
-          return props.onClick(e, props.data, index);
+        onClick: props.onClick && function (e) {
+          // @ts-ignore
+          props.onClick(e, props.data, index);
         }
       });
     });

--- a/src/Chart/renderSegments.tsx
+++ b/src/Chart/renderSegments.tsx
@@ -69,18 +69,24 @@ export default function renderSegments(
         fill="none"
         onMouseOver={
           props.onMouseOver &&
-          // @ts-ignore
-          ((e: React.MouseEvent) => props.onMouseOver(e, props.data, index))
+          ((e: React.MouseEvent) => {
+            // @ts-ignore
+            props.onMouseOver(e, props.data, index);
+          })
         }
         onMouseOut={
           props.onMouseOut &&
-          // @ts-ignore
-          ((e: React.MouseEvent) => props.onMouseOut(e, props.data, index))
+          ((e: React.MouseEvent) => {
+            // @ts-ignore
+            props.onMouseOut(e, props.data, index);
+          })
         }
         onClick={
           props.onClick &&
-          // @ts-ignore
-          ((e: React.MouseEvent) => props.onClick(e, props.data, index))
+          ((e: React.MouseEvent) => {
+            // @ts-ignore
+            props.onClick(e, props.data, index);
+          })
         }
       />
     );

--- a/src/Path.tsx
+++ b/src/Path.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import partialCircle from 'svg-partial-circle';
 import { degreesToRadians, extractPercentage, valueBetween } from './utils';
+import { StyleObject } from './commonTypes';
 
 function makePathCommands(
   cx: number,
@@ -25,13 +26,20 @@ function makePathCommands(
 type Props = {
   cx: number;
   cy: number;
-  startAngle: number;
+  fill?: string;
   lengthAngle: number;
-  radius: number;
   lineWidth: number;
+  key?: number | string;
+  onMouseOver?: (event: React.MouseEvent) => void;
+  onMouseOut?: (event: React.MouseEvent) => void;
+  onClick?: (event: React.MouseEvent) => void;
+  radius: number;
   reveal?: number;
+  startAngle: number;
+  stroke?: string;
+  strokeLinecap?: 'butt' | 'round' | 'square' | 'inherit';
+  style?: StyleObject;
   title?: string | number;
-  [key: string]: any;
 };
 
 export default function ReactMinimalPieChartPath({


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Internal refactoring

### What is the current behaviour? _(You can also link to an open issue here)_

`Path` components types are defined loosely by accepting any kind of optional props.

### What is the new behaviour?

Make each `Path` prop explicitly typed,

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No, `Path` is not publicly exposed.

### Other information:

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
