### PR TITLE
Prevent animation attributes from being uselessy evaluated

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -270,27 +270,12 @@ exports[`Dist bundle is unchanged 1`] = `
     };
   }
 
-  function renderSegments(data, props, hide) {
-    if (hide === void 0) {
-      hide = false;
-    }
-
+  function renderSegments(data, props, forcedReveal) {
     var style = props.segmentsStyle;
 
     if (props.animate) {
       var transitionStyle = makeSegmentTransitionStyle(props.animationDuration, props.animationEasing, style);
       style = Object.assign({}, style, transitionStyle);
-    } // Hide/reveal the segment?
-
-
-    var reveal;
-
-    if (hide === true) {
-      reveal = 0;
-    } else if (typeof props.reveal === 'number') {
-      reveal = props.reveal;
-    } else if (hide === false) {
-      reveal = 100;
     }
 
     var _extractAbsoluteCoord = extractAbsoluteCoordinates(props),
@@ -309,7 +294,7 @@ exports[`Dist bundle is unchanged 1`] = `
         lengthAngle: dataEntry.degrees,
         radius: radius,
         lineWidth: lineWidth,
-        reveal: reveal,
+        reveal: forcedReveal != null ? forcedReveal : props.reveal,
         title: dataEntry.title,
         style: Object.assign({}, style, dataEntry.style),
         stroke: dataEntry.color,
@@ -368,12 +353,12 @@ exports[`Dist bundle is unchanged 1`] = `
       var _this;
 
       _this = _Component.call(this, props) || this;
-      _this.hideSegments = false;
+      _this.forcedSegmentsReveal = void 0;
       _this.initialAnimationTimerId = void 0;
       _this.initialAnimationRAFId = void 0;
 
       if (props.animate === true) {
-        _this.hideSegments = true;
+        _this.forcedSegmentsReveal = 0;
       }
 
       return _this;
@@ -407,7 +392,9 @@ exports[`Dist bundle is unchanged 1`] = `
     };
 
     _proto.startAnimation = function startAnimation() {
-      this.hideSegments = false;
+      var _this$props$reveal;
+
+      this.forcedSegmentsReveal = (_this$props$reveal = this.props.reveal) != null ? _this$props$reveal : 100;
       this.forceUpdate();
     };
 
@@ -429,7 +416,7 @@ exports[`Dist bundle is unchanged 1`] = `
         style: {
           display: 'block'
         }
-      }, renderSegments(extendedData, props, this.hideSegments), props.label && renderLabels(extendedData, props), props.injectSvg && props.injectSvg()), props.children);
+      }, renderSegments(extendedData, props, this.forcedSegmentsReveal), props.label && renderLabels(extendedData, props), props.injectSvg && props.injectSvg()), props.children);
     };
 
     return ReactMinimalPieChart;

--- a/src/Chart/index.tsx
+++ b/src/Chart/index.tsx
@@ -95,7 +95,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
     viewBoxSize: PropTypes.arrayOf(PropTypes.number),
   };
 
-  hideSegments: boolean = false;
+  forcedSegmentsReveal?: number | undefined;
   initialAnimationTimerId?: null | number;
   initialAnimationRAFId?: null | number;
 
@@ -103,7 +103,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
     super(props);
 
     if (props.animate === true) {
-      this.hideSegments = true;
+      this.forcedSegmentsReveal = 0;
     }
   }
 
@@ -129,7 +129,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
   }
 
   startAnimation() {
-    this.hideSegments = false;
+    this.forcedSegmentsReveal = this.props.reveal ?? 100;
     this.forceUpdate();
   }
 
@@ -148,7 +148,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
           height="100%"
           style={{ display: 'block' }}
         >
-          {renderSegments(extendedData, props, this.hideSegments)}
+          {renderSegments(extendedData, props, this.forcedSegmentsReveal)}
           {props.label && renderLabels(extendedData, props)}
           {props.injectSvg && props.injectSvg()}
         </svg>

--- a/src/Chart/renderSegments.tsx
+++ b/src/Chart/renderSegments.tsx
@@ -25,7 +25,7 @@ function makeSegmentTransitionStyle(
 export default function renderSegments(
   data: ExtendedData,
   props: ChartProps,
-  hide: Boolean = false
+  forcedReveal?: number
 ) {
   let style = props.segmentsStyle;
   if (props.animate) {
@@ -35,16 +35,6 @@ export default function renderSegments(
       style
     );
     style = Object.assign({}, style, transitionStyle);
-  }
-
-  // Hide/reveal the segment?
-  let reveal: number;
-  if (hide === true) {
-    reveal = 0;
-  } else if (typeof props.reveal === 'number') {
-    reveal = props.reveal;
-  } else if (hide === false) {
-    reveal = 100;
   }
 
   const { cx, cy, radius } = extractAbsoluteCoordinates(props);
@@ -61,7 +51,7 @@ export default function renderSegments(
         lengthAngle={dataEntry.degrees}
         radius={radius}
         lineWidth={lineWidth}
-        reveal={reveal}
+        reveal={forcedReveal ?? props.reveal}
         title={dataEntry.title}
         style={Object.assign({}, style, dataEntry.style)}
         stroke={dataEntry.color}

--- a/src/__tests__/Chart.test.tsx
+++ b/src/__tests__/Chart.test.tsx
@@ -193,26 +193,41 @@ describe('Chart', () => {
       });
     });
 
-    it('re-render on did mount updating segments\' "reveal" prop from 0 to 100', () => {
-      const pathLength = degreesToRadians(25) * 360;
-      const singleEntryDataMock = [...dataMock[0]];
-      const { container } = render({
-        data: singleEntryDataMock,
-        animate: true,
+    describe.each([
+      [undefined, 360],
+      [50, 180],
+    ])('"reveal === %s"', (reveal, expectedRevealedDegrees) => {
+      it('re-render on did mount revealing the expected portion of segment', () => {
+        const segmentRadius = 25;
+        const lengthAngle = 360;
+        const fullPathLength = degreesToRadians(segmentRadius) * lengthAngle;
+
+        const singleEntryDataMock = [...dataMock[0]];
+        const { container } = render({
+          data: singleEntryDataMock,
+          animate: true,
+          lengthAngle,
+          reveal,
+        });
+
+        const path = container.querySelector('path');
+
+        // Path hidden
+        expect(path).toHaveAttribute('stroke-dasharray', `${fullPathLength}`);
+        expect(path).toHaveAttribute('stroke-dashoffset', `${fullPathLength}`);
+
+        // Complete componentDidMount callback execution
+        jest.runAllTimers();
+
+        const expectedRevealedPathLength =
+          (fullPathLength / lengthAngle) * expectedRevealedDegrees;
+
+        expect(path).toHaveAttribute('stroke-dasharray', `${fullPathLength}`);
+        expect(path).toHaveAttribute(
+          'stroke-dashoffset',
+          `${fullPathLength - expectedRevealedPathLength}`
+        );
       });
-
-      const path = container.querySelector('path');
-
-      // Path hidden
-      expect(path).toHaveAttribute('stroke-dasharray', `${pathLength}`);
-      expect(path).toHaveAttribute('stroke-dashoffset', `${pathLength}`);
-
-      // Complete componentDidMount callback execution
-      jest.runAllTimers();
-
-      // Path fully revealed
-      expect(path).toHaveAttribute('stroke-dasharray', `${pathLength}`);
-      expect(path).toHaveAttribute('stroke-dashoffset', '0');
     });
 
     it("don't re-render when component is unmounted", () => {

--- a/src/__tests__/Path.test.tsx
+++ b/src/__tests__/Path.test.tsx
@@ -63,6 +63,18 @@ describe('Path', () => {
     const pathLength = degreesToRadians(25) * 360;
     const singleEntryDataMock = [...dataMock[0]];
 
+    describe('undefined', () => {
+      it('render a fully revealed path without "strokeDasharray" nor "strokeDashoffset"', () => {
+        const { container } = render({
+          data: singleEntryDataMock,
+        });
+
+        const path = container.querySelector('path');
+        expect(path).not.toHaveAttribute('stroke-dasharray');
+        expect(path).not.toHaveAttribute('stroke-dashoffset');
+      });
+    });
+
     describe('100', () => {
       it('render a fully revealed path with "strokeDasharray" === path length & "strokeDashoffset" === 0', () => {
         const { container } = render({


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

v7.0.0 [introduced a regression bug ](https://github.com/toomuchdesign/react-minimal-pie-chart/blame/f8cd27b1de5ff3b9b253a9884d890a6cf1460e82/src/Chart/index.tsx#L98)consisting of `stroke-dasharray` and `stroke-dashoffset` attributes being evaluated and appended even when there is no animation.

### What is the new behaviour?
This PR fixes the regression bug and add tests to cover this specific case.

It also gets rid of one of the most [cumbersome lines of code](https://github.com/toomuchdesign/react-minimal-pie-chart/blob/f8cd27b1de5ff3b9b253a9884d890a6cf1460e82/src/Chart/renderSegments.tsx#L41) of this library.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes, but it reverts the library to its expected behaviour.

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
