### PR TITLE
Fix reveal prop stuck after initial animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.1.1
+
+### Bugfixes
+
+- Fix regression introduced in `7.1.0` consisting of `reveal` prop being stuck after initial animation
+
 # 7.1.0
 
 ### New Features

--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -110,6 +110,9 @@ exports[`Dist bundle is unchanged 1`] = `
       radius: extractPercentage(props.radius, viewBoxWidth)
     };
   }
+  function isNumber(value) {
+    return typeof value === 'number';
+  }
 
   function sumValues(data) {
     return data.reduce(function (acc, dataEntry) {
@@ -248,7 +251,7 @@ exports[`Dist bundle is unchanged 1`] = `
     var strokeDashoffset; // Animate/hide paths with \\"stroke-dasharray\\" + \\"stroke-dashoffset\\"
     // https://css-tricks.com/svg-line-animation-works/
 
-    if (typeof reveal === 'number') {
+    if (isNumber(reveal)) {
       var pathLength = degreesToRadians(actualRadio) * lengthAngle;
       strokeDasharray = Math.abs(pathLength);
       strokeDashoffset = strokeDasharray - extractPercentage(strokeDasharray, reveal);
@@ -276,13 +279,24 @@ exports[`Dist bundle is unchanged 1`] = `
     };
   }
 
-  function renderSegments(data, props, forcedReveal) {
+  function getRevealValue(props) {
+    //@NOTE When animation is on, chart has to be fully revealed when reveal is not set
+    if (props.animate && !isNumber(props.reveal)) {
+      return 100;
+    }
+
+    return props.reveal;
+  }
+
+  function renderSegments(data, props, revealOverride) {
     var style = props.segmentsStyle;
 
     if (props.animate) {
       var transitionStyle = makeSegmentTransitionStyle(props.animationDuration, props.animationEasing, style);
       style = Object.assign({}, style, transitionStyle);
     }
+
+    var reveal = revealOverride != null ? revealOverride : getRevealValue(props);
 
     var _extractAbsoluteCoord = extractAbsoluteCoordinates(props),
         cx = _extractAbsoluteCoord.cx,
@@ -300,7 +314,7 @@ exports[`Dist bundle is unchanged 1`] = `
         lengthAngle: dataEntry.degrees,
         radius: radius,
         lineWidth: lineWidth,
-        reveal: forcedReveal != null ? forcedReveal : props.reveal,
+        reveal: reveal,
         title: dataEntry.title,
         style: Object.assign({}, style, dataEntry.style),
         stroke: dataEntry.color,
@@ -359,12 +373,12 @@ exports[`Dist bundle is unchanged 1`] = `
       var _this;
 
       _this = _Component.call(this, props) || this;
-      _this.forcedSegmentsReveal = void 0;
+      _this.revealOverride = void 0;
       _this.initialAnimationTimerId = void 0;
       _this.initialAnimationRAFId = void 0;
 
       if (props.animate === true) {
-        _this.forcedSegmentsReveal = 0;
+        _this.revealOverride = 0;
       }
 
       return _this;
@@ -398,9 +412,7 @@ exports[`Dist bundle is unchanged 1`] = `
     };
 
     _proto.startAnimation = function startAnimation() {
-      var _this$props$reveal;
-
-      this.forcedSegmentsReveal = (_this$props$reveal = this.props.reveal) != null ? _this$props$reveal : 100;
+      this.revealOverride = null;
       this.forceUpdate();
     };
 
@@ -422,7 +434,7 @@ exports[`Dist bundle is unchanged 1`] = `
         style: {
           display: 'block'
         }
-      }, renderSegments(extendedData, props, this.forcedSegmentsReveal), props.label && renderLabels(extendedData, props), props.injectSvg && props.injectSvg()), props.children);
+      }, renderSegments(extendedData, props, this.revealOverride), props.label && renderLabels(extendedData, props), props.injectSvg && props.injectSvg()), props.children);
     };
 
     return ReactMinimalPieChart;

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -100,7 +100,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
     viewBoxSize: PropTypes.arrayOf(PropTypes.number),
   };
 
-  forcedSegmentsReveal?: number | undefined;
+  revealOverride?: null | number;
   initialAnimationTimerId?: null | number;
   initialAnimationRAFId?: null | number;
 
@@ -108,7 +108,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
     super(props);
 
     if (props.animate === true) {
-      this.forcedSegmentsReveal = 0;
+      this.revealOverride = 0;
     }
   }
 
@@ -134,7 +134,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
   }
 
   startAnimation() {
-    this.forcedSegmentsReveal = this.props.reveal ?? 100;
+    this.revealOverride = null;
     this.forceUpdate();
   }
 
@@ -153,7 +153,7 @@ export default class ReactMinimalPieChart extends Component<Props> {
           height="100%"
           style={{ display: 'block' }}
         >
-          {renderSegments(extendedData, props, this.forcedSegmentsReveal)}
+          {renderSegments(extendedData, props, this.revealOverride)}
           {props.label && renderLabels(extendedData, props)}
           {props.injectSvg && props.injectSvg()}
         </svg>

--- a/src/Chart/renderSegments.tsx
+++ b/src/Chart/renderSegments.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Path from '../Path';
-import { extractPercentage, extractAbsoluteCoordinates } from '../utils';
+import {
+  extractPercentage,
+  extractAbsoluteCoordinates,
+  isNumber,
+} from '../utils';
 import type { ExtendedData, StyleObject } from '../commonTypes';
 import type { Props as ChartProps } from './Chart';
 
@@ -19,10 +23,18 @@ function makeSegmentTransitionStyle(
   };
 }
 
+function getRevealValue<Reveal>(props: { reveal?: Reveal; animate: boolean }) {
+  //@NOTE When animation is on, chart has to be fully revealed when reveal is not set
+  if (props.animate && !isNumber(props.reveal)) {
+    return 100;
+  }
+  return props.reveal;
+}
+
 export default function renderSegments(
   data: ExtendedData,
   props: ChartProps,
-  forcedReveal?: number
+  revealOverride?: null | number
 ) {
   let style = props.segmentsStyle;
   if (props.animate) {
@@ -33,6 +45,7 @@ export default function renderSegments(
     );
     style = Object.assign({}, style, transitionStyle);
   }
+  const reveal = revealOverride ?? getRevealValue(props);
 
   const { cx, cy, radius } = extractAbsoluteCoordinates(props);
   const lineWidth = extractPercentage(radius, props.lineWidth);
@@ -48,7 +61,7 @@ export default function renderSegments(
         lengthAngle={dataEntry.degrees}
         radius={radius}
         lineWidth={lineWidth}
-        reveal={forcedReveal ?? props.reveal}
+        reveal={reveal}
         title={dataEntry.title}
         style={Object.assign({}, style, dataEntry.style)}
         stroke={dataEntry.color}

--- a/src/Path.tsx
+++ b/src/Path.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import partialCircle from 'svg-partial-circle';
-import { degreesToRadians, extractPercentage, valueBetween } from './utils';
+import {
+  degreesToRadians,
+  extractPercentage,
+  isNumber,
+  valueBetween,
+} from './utils';
 import type { StyleObject } from './commonTypes';
 
 export function makePathCommands(
@@ -70,7 +75,7 @@ export default function ReactMinimalPieChartPath({
 
   // Animate/hide paths with "stroke-dasharray" + "stroke-dashoffset"
   // https://css-tricks.com/svg-line-animation-works/
-  if (typeof reveal === 'number') {
+  if (isNumber(reveal)) {
     const pathLength = degreesToRadians(actualRadio) * lengthAngle;
     strokeDasharray = Math.abs(pathLength);
     strokeDashoffset =

--- a/src/__tests__/testUtils/render.js
+++ b/src/__tests__/testUtils/render.js
@@ -11,7 +11,13 @@ export const dataMock = [
 
 export function render(props) {
   const defaultProps = { data: dataMock };
-  return TLRender(<PieChart {...defaultProps} {...props} />);
+  const instance = TLRender(<PieChart {...defaultProps} {...props} />);
+
+  // Uniform rerender to render's API
+  const { rerender } = instance;
+  instance.rerender = (props) =>
+    rerender(<PieChart {...defaultProps} {...props} />);
+  return instance;
 }
 
 export { PieChart };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,3 +54,7 @@ export function extractAbsoluteCoordinates(props: ChartProps) {
     radius: extractPercentage(props.radius, viewBoxWidth),
   };
 }
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

53c2e69cb500d7e9af287cffd93b817a21b82a42 Introduced a bug concerning `reveal` prop getting stuck after initial animation

### What is the new behaviour?

This PR provide a bugfix and tests

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
