### PR TITLE
Fix wrong label position when segmentsShift enabled (#155)

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -207,7 +207,8 @@ exports[`Dist bundle is unchanged 1`] = `
     return data.map(function (dataEntry, index) {
       var _functionProp;
 
-      var distanceFromCenter = extractPercentage(radius, (_functionProp = functionProp(props.segmentsShift, data, index)) != null ? _functionProp : 0 + props.labelPosition);
+      var segmentsShift = (_functionProp = functionProp(props.segmentsShift, data, index)) != null ? _functionProp : 0;
+      var distanceFromCenter = extractPercentage(radius, props.labelPosition + segmentsShift);
       var startAngle = props.startAngle + dataEntry.startOffset;
       var segmentBisector = bisectorAngle(startAngle, dataEntry.degrees);
 

--- a/src/Chart/renderLabels.tsx
+++ b/src/Chart/renderLabels.tsx
@@ -36,9 +36,10 @@ function renderLabelItem(
 export default function renderLabels(data: ExtendedData, props: ChartProps) {
   const { cx, cy, radius } = extractAbsoluteCoordinates(props);
   return data.map((dataEntry, index) => {
+    const segmentsShift = functionProp(props.segmentsShift, data, index) ?? 0;
     const distanceFromCenter = extractPercentage(
       radius,
-      functionProp(props.segmentsShift, data, index) ?? 0 + props.labelPosition
+      props.labelPosition + segmentsShift
     );
     const startAngle = props.startAngle + dataEntry.startOffset;
     const segmentBisector = bisectorAngle(startAngle, dataEntry.degrees);

--- a/src/__tests__/Path.test.tsx
+++ b/src/__tests__/Path.test.tsx
@@ -122,17 +122,16 @@ describe('Path', () => {
         const { container, getAllByText } = render({
           segmentsShift,
           label: () => 'label',
-          labelPosition: 0, // Render labels at the segments' origin
         });
         const paths = container.querySelectorAll('path');
         const shiftedLabels = getAllByText('label');
 
         shiftedLabels.forEach((label, index) => {
+          const { startAngle, lengthAngle } = getArcInfo(paths[index]);
           const expectedAbsoluteShift = extractPercentage(
             PieChart.defaultProps.radius,
-            expectedSegmentsShift[index]
+            expectedSegmentsShift[index] + PieChart.defaultProps.labelPosition
           );
-          const { startAngle, lengthAngle } = getArcInfo(paths[index]);
           const { dx, dy } = shiftVectorAlongAngle(
             bisectorAngle(startAngle, lengthAngle),
             expectedAbsoluteShift


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

#155 

### What is the new behaviour?

Rephrased the line which caused the bug. Tests did catch the bug because of a test implementation detail which set `labelPosition` to 0. 🙀

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated