### PR TITLE
Event handler types fix

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -322,7 +322,15 @@ exports[`Dist bundle is unchanged 1`] = `
   function renderSegments(data, props, revealOverride) {
     // @NOTE this should go in Path component. Here for performance reasons
     var reveal = revealOverride != null ? revealOverride : getRevealValue(props);
-    var segmentTransitionsCombined = props.animate && makeSegmentTransitionStyle(props.animationDuration, props.animationEasing, props.segmentsStyle);
+    var segmentTransitionsCombined = props.animate && makeSegmentTransitionStyle(props.animationDuration, props.animationEasing, props.segmentsStyle); // @NOTE TS can't keep track of existence check (eg. props.onBlur && ...) of object properties
+    // @TODO Find a better solution then extracting props (.bind() or second && check inside callback)
+
+    var onBlur = props.onBlur,
+        onClick = props.onClick,
+        onFocus = props.onFocus,
+        onKeyDown = props.onKeyDown,
+        onMouseOut = props.onMouseOut,
+        onMouseOver = props.onMouseOver;
 
     var _extractAbsoluteCoord = extractAbsoluteCoordinates(props),
         cx = _extractAbsoluteCoord.cx,
@@ -348,29 +356,23 @@ exports[`Dist bundle is unchanged 1`] = `
         strokeLinecap: props.rounded ? 'round' : undefined,
         tabIndex: props.segmentsTabIndex,
         fill: \\"none\\",
-        onBlur: props.onBlur && function (e) {
-          // @ts-ignore
-          props.onBlur(e, props.data, index);
+        onBlur: onBlur && function (e) {
+          onBlur(e, props.data, index);
         },
-        onClick: props.onClick && function (e) {
-          // @ts-ignore
-          props.onClick(e, props.data, index);
+        onClick: onClick && function (e) {
+          onClick(e, props.data, index);
         },
-        onFocus: props.onFocus && function (e) {
-          // @ts-ignore
-          props.onFocus(e, props.data, index);
+        onFocus: onFocus && function (e) {
+          onFocus(e, props.data, index);
         },
-        onKeyDown: props.onKeyDown && function (e) {
-          // @ts-ignore
-          props.onKeyDown(e, props.data, index);
+        onKeyDown: onKeyDown && function (e) {
+          onKeyDown(e, props.data, index);
         },
-        onMouseOver: props.onMouseOver && function (e) {
-          // @ts-ignore
-          props.onMouseOver(e, props.data, index);
+        onMouseOver: onMouseOver && function (e) {
+          onMouseOver(e, props.data, index);
         },
-        onMouseOut: props.onMouseOut && function (e) {
-          // @ts-ignore
-          props.onMouseOut(e, props.data, index);
+        onMouseOut: onMouseOut && function (e) {
+          onMouseOut(e, props.data, index);
         }
       });
     });

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import type { FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 import PropTypes from 'prop-types';
 import { dataPropType, stylePropType } from '../propTypes';
 import extendData from './extendData';
@@ -27,12 +28,12 @@ export type Props = Omit<typeof ReactMinimalPieChart.defaultProps, 'label'> & {
   label?: LabelProp;
   labelPosition?: number;
   labelStyle?: StyleObject;
-  onBlur?: EventHandler;
-  onClick?: EventHandler;
-  onFocus?: EventHandler;
-  onKeyDown?: EventHandler;
-  onMouseOut?: EventHandler;
-  onMouseOver?: EventHandler;
+  onBlur?: EventHandler<FocusEvent>;
+  onClick?: EventHandler<MouseEvent>;
+  onFocus?: EventHandler<FocusEvent>;
+  onKeyDown?: EventHandler<KeyboardEvent>;
+  onMouseOut?: EventHandler<MouseEvent>;
+  onMouseOver?: EventHandler<MouseEvent>;
   paddingAngle?: number;
   radius?: number;
   reveal?: number;

--- a/src/Chart/renderSegments.tsx
+++ b/src/Chart/renderSegments.tsx
@@ -47,6 +47,17 @@ export default function renderSegments(
       props.segmentsStyle
     );
 
+  // @NOTE TS can't keep track of existence check (eg. props.onBlur && ...) of object properties
+  // @TODO Find a better solution then extracting props (.bind() or second && check inside callback)
+  const {
+    onBlur,
+    onClick,
+    onFocus,
+    onKeyDown,
+    onMouseOut,
+    onMouseOver,
+  } = props;
+
   const { cx, cy, radius } = extractAbsoluteCoordinates(props);
   const lineWidth = extractPercentage(radius, props.lineWidth);
   const paths = data.map((dataEntry, index) => {
@@ -74,45 +85,39 @@ export default function renderSegments(
         tabIndex={props.segmentsTabIndex}
         fill="none"
         onBlur={
-          props.onBlur &&
-          ((e: React.FocusEvent) => {
-            // @ts-ignore
-            props.onBlur(e, props.data, index);
+          onBlur &&
+          ((e) => {
+            onBlur(e, props.data, index);
           })
         }
         onClick={
-          props.onClick &&
-          ((e: React.MouseEvent) => {
-            // @ts-ignore
-            props.onClick(e, props.data, index);
+          onClick &&
+          ((e) => {
+            onClick(e, props.data, index);
           })
         }
         onFocus={
-          props.onFocus &&
-          ((e: React.FocusEvent) => {
-            // @ts-ignore
-            props.onFocus(e, props.data, index);
+          onFocus &&
+          ((e) => {
+            onFocus(e, props.data, index);
           })
         }
         onKeyDown={
-          props.onKeyDown &&
-          ((e: React.KeyboardEvent) => {
-            // @ts-ignore
-            props.onKeyDown(e, props.data, index);
+          onKeyDown &&
+          ((e) => {
+            onKeyDown(e, props.data, index);
           })
         }
         onMouseOver={
-          props.onMouseOver &&
-          ((e: React.MouseEvent) => {
-            // @ts-ignore
-            props.onMouseOver(e, props.data, index);
+          onMouseOver &&
+          ((e) => {
+            onMouseOver(e, props.data, index);
           })
         }
         onMouseOut={
-          props.onMouseOut &&
-          ((e: React.MouseEvent) => {
-            // @ts-ignore
-            props.onMouseOut(e, props.data, index);
+          onMouseOut &&
+          ((e) => {
+            onMouseOut(e, props.data, index);
           })
         }
       />

--- a/src/__tests__/types.tsx
+++ b/src/__tests__/types.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import type { FocusEvent, KeyboardEvent, MouseEvent } from 'react';
 import PieChart from '../../src';
+import type { Props as PieChartProps } from '../../src/Chart';
+type Data = PieChartProps['data'];
 
 <PieChart data={[]} />;
 <PieChart
@@ -44,15 +47,14 @@ import PieChart from '../../src';
 //@ts-ignore
 <PieChart data={[]} segmentsShift={() => {}} />;
 
-//@TODO update with actual event type
 <PieChart
   data={[]}
-  onBlur={(e) => {}}
-  onClick={(e) => {}}
-  onFocus={(e) => {}}
-  onKeyDown={(e) => {}}
-  onMouseOut={(e) => {}}
-  onMouseOver={(e) => {}}
+  onBlur={(e: FocusEvent, data: Data, index: number) => {}}
+  onClick={(e: MouseEvent, data: Data, index: number) => {}}
+  onFocus={(e: FocusEvent, data: Data, index: number) => {}}
+  onKeyDown={(e: KeyboardEvent, data: Data, index: number) => {}}
+  onMouseOut={(e: MouseEvent, data: Data, index: number) => {}}
+  onMouseOver={(e: MouseEvent, data: Data, index: number) => {}}
 />;
 
 <PieChart data={[]}>1</PieChart>;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -5,8 +5,8 @@ export type StyleObject = {
   [key: string]: string | number;
 };
 
-export type EventHandler = (
-  event: React.MouseEvent,
+export type EventHandler<Event> = (
+  event: Event,
   data: Data,
   dataIndex: number
 ) => void;


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Types Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_
`onBlur`, `onFocus` and `onKeyDown` types expect wrong `MouseEvent` event type.

### What is the new behaviour?

Assign correct event type and enable type checking on the lines which had it disabled.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
