### PR TITLE
Fix stroke-dashoffset attribute zero rounding error

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -18,7 +18,7 @@ exports[`Dist bundle is unchanged 1`] = `
     return value;
   }
   function extractPercentage(value, percentage) {
-    return value * percentage / 100;
+    return percentage / 100 * value;
   }
   function bisectorAngle(startAngle, lengthAngle) {
     return startAngle + lengthAngle / 2;

--- a/src/__tests__/Chart.test.tsx
+++ b/src/__tests__/Chart.test.tsx
@@ -188,13 +188,12 @@ describe('Chart', () => {
     `('reveal === ${reveal}', ({ reveal, expectedRevealedPercentage }) => {
       it('re-render on did mount revealing the expected portion of segment', () => {
         const segmentRadius = PieChart.defaultProps.radius / 2;
-        const lengthAngle = 360;
+        const lengthAngle = PieChart.defaultProps.lengthAngle;
         const fullPathLength = degreesToRadians(segmentRadius) * lengthAngle;
         let hiddenPercentage;
         const initialProps = {
           data: [...dataMock[0]],
           animate: true,
-          lengthAngle,
           reveal,
         };
         const { container, rerender } = render(initialProps);
@@ -253,6 +252,25 @@ describe('Chart', () => {
 
       console.error.mockRestore();
       expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    describe('stroke-dashoffset attribute', () => {
+      it("doesn't generate zero rounding issues after animation (GitHub: #133)", () => {
+        const { container } = render({
+          data: [{ value: 1 }, { value: 1.6 }],
+          animate: true,
+        });
+
+        // Trigger async initial animation
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        // Expect all segments to be fully exposed
+        container.querySelectorAll('path').forEach((path) => {
+          expect(path).toHaveAttribute('stroke-dashoffset', '0');
+        });
+      });
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export function valueBetween(value: number, min: number, max: number) {
 }
 
 export function extractPercentage(value: number, percentage: number) {
-  return (value * percentage) / 100;
+  return (percentage / 100) * value;
 }
 
 export function bisectorAngle(startAngle: number, lengthAngle: number) {


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix, still to be implemented.

### What is the current behaviour? _(You can also link to an open issue here)_

#133

### What is the new behaviour?

Expect `stroke-dashoffset` attribute to always exactly equal 0 after animation. This PR redefines `extractPercentage` implementation to avoid rounding errors when percentage is 100 or 0.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
