### PR TITLE
feat: rely on function names for displayName (2% bundle size reduction)

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -94,7 +94,7 @@ exports[`Dist bundle is unchanged 1`] = `
     return target;
   }
 
-  function Label(_ref) {
+  function ReactMinimalPieChartLabel(_ref) {
     var dataEntry = _ref.dataEntry,
         dataIndex = _ref.dataIndex,
         props = _objectWithoutPropertiesLoose(_ref, [\\"dataEntry\\", \\"dataIndex\\"]);
@@ -103,7 +103,6 @@ exports[`Dist bundle is unchanged 1`] = `
       dominantBaseline: \\"central\\"
     }, props));
   }
-  Label.displayName = 'ReactMinimalPieChartLabel';
 
   function round(number) {
     var divisor = 1e14; // 14 decimals
@@ -141,7 +140,7 @@ exports[`Dist bundle is unchanged 1`] = `
     var label = renderLabel(labelProps);
 
     if (typeof label === 'string' || typeof label === 'number') {
-      return /*#__PURE__*/React__default.createElement(Label, Object.assign({
+      return /*#__PURE__*/React__default.createElement(ReactMinimalPieChartLabel, Object.assign({
         key: \\"label-\\" + (labelProps.dataEntry.key || labelProps.dataIndex)
       }, labelProps), label);
     }
@@ -204,7 +203,7 @@ exports[`Dist bundle is unchanged 1`] = `
       return command.join(' ');
     }).join(' ');
   }
-  function Path(_ref) {
+  function ReactMinimalPieChartPath(_ref) {
     var cx = _ref.cx,
         cy = _ref.cy,
         lengthAngle = _ref.lengthAngle,
@@ -244,7 +243,6 @@ exports[`Dist bundle is unchanged 1`] = `
       strokeLinecap: rounded ? 'round' : undefined
     }, props), title && /*#__PURE__*/React__default.createElement(\\"title\\", null, title));
   }
-  Path.displayName = 'ReactMinimalPieChartPath';
 
   function combineSegmentTransitionsStyle(duration, easing, customStyle) {
     // Merge chart's animation CSS transition with \\"transition\\" found to customStyle
@@ -284,7 +282,7 @@ exports[`Dist bundle is unchanged 1`] = `
     var lineWidth = extractPercentage(radius, props.lineWidth);
     var paths = data.map(function (dataEntry, index) {
       var segmentsStyle = functionProp(props.segmentsStyle, index);
-      return /*#__PURE__*/React__default.createElement(Path, {
+      return /*#__PURE__*/React__default.createElement(ReactMinimalPieChartPath, {
         cx: cx,
         cy: cy,
         key: dataEntry.key || index,
@@ -309,7 +307,7 @@ exports[`Dist bundle is unchanged 1`] = `
     });
 
     if (props.background) {
-      paths.unshift( /*#__PURE__*/React__default.createElement(Path, {
+      paths.unshift( /*#__PURE__*/React__default.createElement(ReactMinimalPieChartPath, {
         cx: cx,
         cy: cy,
         key: \\"bg\\",
@@ -338,7 +336,7 @@ exports[`Dist bundle is unchanged 1`] = `
     startAngle: 0,
     viewBoxSize: [100, 100]
   };
-  function PieChart(props) {
+  function ReactMinimalPieChart(props) {
     var _useState = React.useState(props.animate ? 0 : null),
         revealOverride = _useState[0],
         setRevealOverride = _useState[1];
@@ -373,10 +371,9 @@ exports[`Dist bundle is unchanged 1`] = `
       style: props.style
     }, renderSegments(extendedData, props, revealOverride), props.label && renderLabels(extendedData, props), props.children);
   }
-  PieChart.defaultProps = defaultProps;
-  PieChart.displayName = 'ReactMinimalPieChart';
+  ReactMinimalPieChart.defaultProps = defaultProps;
 
-  exports.PieChart = PieChart;
+  exports.PieChart = ReactMinimalPieChart;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -64,7 +64,7 @@ const defaultProps = {
 
 export type PropsWithDefaults = Props & typeof defaultProps;
 
-export function PieChart(props: PropsWithDefaults) {
+export function ReactMinimalPieChart(props: PropsWithDefaults) {
   const [revealOverride, setRevealOverride] = useState(
     props.animate ? 0 : null
   );
@@ -107,5 +107,4 @@ export function PieChart(props: PropsWithDefaults) {
   );
 }
 
-PieChart.defaultProps = defaultProps;
-PieChart.displayName = 'ReactMinimalPieChart';
+ReactMinimalPieChart.defaultProps = defaultProps;

--- a/src/Chart/index.tsx
+++ b/src/Chart/index.tsx
@@ -1,1 +1,1 @@
-export { PieChart } from './Chart';
+export { ReactMinimalPieChart as PieChart } from './Chart';

--- a/src/Chart/renderSegments.tsx
+++ b/src/Chart/renderSegments.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CSSProperties } from 'react';
-import Path from '../Path';
+import ReactMinimalPieChartPath from '../Path';
 import { extractPercentage, functionProp, isNumber } from '../utils';
 import type { ExtendedData } from '../commonTypes';
 import type { PropsWithDefaults as ChartProps } from './Chart';
@@ -55,7 +55,7 @@ export default function renderSegments(
   const paths = data.map((dataEntry, index) => {
     const segmentsStyle = functionProp(props.segmentsStyle, index);
     return (
-      <Path
+      <ReactMinimalPieChartPath
         cx={cx}
         cy={cy}
         key={dataEntry.key || index}
@@ -91,7 +91,7 @@ export default function renderSegments(
 
   if (props.background) {
     paths.unshift(
-      <Path
+      <ReactMinimalPieChartPath
         cx={cx}
         cy={cy}
         key="bg"

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -15,8 +15,10 @@ export type LabelRenderProps = {
 
 type Props = SVGProps<SVGTextElement> & LabelRenderProps;
 
-export default function Label({ dataEntry, dataIndex, ...props }: Props) {
+export default function ReactMinimalPieChartLabel({
+  dataEntry,
+  dataIndex,
+  ...props
+}: Props) {
   return <text dominantBaseline="central" {...props} />;
 }
-
-Label.displayName = 'ReactMinimalPieChartLabel';

--- a/src/Path.tsx
+++ b/src/Path.tsx
@@ -43,7 +43,7 @@ type Props = SVGProps<SVGPathElement> & {
   title?: string | number;
 };
 
-export default function Path({
+export default function ReactMinimalPieChartPath({
   cx,
   cy,
   lengthAngle,
@@ -96,5 +96,3 @@ export default function Path({
     </path>
   );
 }
-
-Path.displayName = 'ReactMinimalPieChartPath';


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_
Removed displayName property to reduce bundle size. Since strings can't be minified, reducing them affects bundlesize.
For example, having "Path" +  "displayName" + "ReactMinimalPieChartPath" takes 39 characters (or bytes) while ReactMinimalPieChartPath takes 24). Also, I guess you care for how your component appears in the react tree in debugger or profiler, so naming the function itself as the desired component name should do what you want as named functions anyway have a name in React tree:

<img width="431" alt="Screenshot 2020-10-09 at 1 06 42 PM" src="https://user-images.githubusercontent.com/6177621/95556052-4f4bae80-0a30-11eb-8db1-e01d33d78523.png">

...

### What is the current behaviour? _(You can also link to an open issue here)_
Current bundlesize is `1.87 KB with all dependencies, minified and gzipped`
...

### What is the new behaviour?
New bundlesize is ` 1.83 KB with all dependencies, minified and gzipped`. This is a 2% win. 🤷‍♂️
...

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_
I hope not.
...

### Other information:

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
