### PR TITLE
feat: type data with generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,8 @@ This library uses the `stroke-dasharray` + `stroke-dashoffset` animation strateg
 - Consider using `transform` to mutate segments/labels positions
 - Consider exposing a reduced chart variation including just a subset of the features
 - Consider abstracting React bindings to re-use business logic with other frameworks
-- Remove `defaultProps` in favour of JS default arguments
 - Provide a way to supply `svg` element with any extra prop
-- Consider removing `import type` declaration from generated type definition files (if possible) to ensure Typescript 3.0+ backward compatibility
+- Find a better solution to assign default props
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Because [Recharts][recharts-github] is awesome, but when you just need a simple 
 
 |                                                        |                                         Size<br>by Bundlefobia                                          | Benchmark Size \* | Loading time<br>on a slow 3g \* |
 | :----------------------------------------------------: | :-----------------------------------------------------------------------------------------------------: | :---------------: | :-----------------------------: |
-|           react-minimal-pie-chart (_v8.2.0_)           |               [![Bundle size: React minimal pie chart][bundlephobia-badge]][bundlephobia]               |      1.83 KB      |             ~38 ms              |
+|           react-minimal-pie-chart (_v8.4.0_)           |               [![Bundle size: React minimal pie chart][bundlephobia-badge]][bundlephobia]               |      1.93 KB      |             ~39 ms              |
 |         [rechart][recharts-github] (_v1.8.5_)          |             [![Bundle size: Recharts][recharts-bundlephobia-badge]][recharts-bundlephobia]              |      96.9 KB      |            ~1900 ms             |
 |     [victory-pie][victory-pie-github] (_v34.1.3_)      |         [![Bundle size: Victory pie][victory-pie-bundlephobia-badge]][victory-pie-bundlephobia]         |      50.5 KB      |            ~1100 ms             |
 | [react-apexcharts][react-apexcharts-github] (_v1.3.7_) | [![Bundle size: React apec charts][react-apexcharts-bundlephobia-badge]][react-apexcharts-bundlephobia] |     114.6 KB      |            ~2300 ms             |
@@ -100,6 +100,12 @@ import { PieChart } from 'react-minimal-pie-chart';
 | **onMouseOver**       | `(e, segmentIndex) => void`                            | `onMouseOver` event handler for each segment                                                                                                                                                                                                             | -          |
 |  | `.oOo.oOo.oOo.oOo.oOo.oOo.oOo.` | | |
 <!-- prettier-ignore-end -->
+
+Prop types are exposed for convenience:
+
+```ts
+import type { PieChartProps } from 'react-minimal-pie-chart';
+```
 
 ### About `data` prop
 
@@ -205,7 +211,6 @@ This library uses the `stroke-dasharray` + `stroke-dashoffset` animation strateg
 
 - Consider moving storybook deployment to CI
 - Consider using `transform` to mutate segments/labels positions
-- Consider exposing a reduced chart variation including just a subset of the features
 - Consider abstracting React bindings to re-use business logic with other frameworks
 - Provide a way to supply `svg` element with any extra prop
 - Find a better solution to assign default props

--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -107,7 +107,7 @@ exports[`Dist bundle is unchanged 1`] = `
     return target;
   }
 
-  function ReactMinimalPieChartLabel(_ref) {
+  function ReactMinimalPieChartDefaultLabel(_ref) {
     _ref.dataEntry;
         _ref.dataIndex;
         var props = _objectWithoutPropertiesLoose(_ref, [\\"dataEntry\\", \\"dataIndex\\"]);
@@ -115,6 +115,24 @@ exports[`Dist bundle is unchanged 1`] = `
     return /*#__PURE__*/React__default['default'].createElement(\\"text\\", Object.assign({
       dominantBaseline: \\"central\\"
     }, props));
+  }
+
+  function ReactMinimalPieChartLabel(_ref2) {
+    var renderLabel = _ref2.renderLabel,
+        labelProps = _ref2.labelProps;
+    var label = renderLabel(labelProps);
+
+    if (typeof label === 'string' || typeof label === 'number') {
+      return /*#__PURE__*/React__default['default'].createElement(ReactMinimalPieChartDefaultLabel, Object.assign({
+        key: \\"label-\\" + (labelProps.dataEntry.key || labelProps.dataIndex)
+      }, labelProps), label);
+    }
+
+    if (React__default['default'].isValidElement(label)) {
+      return label;
+    }
+
+    return null;
   }
 
   function round(number) {
@@ -149,23 +167,7 @@ exports[`Dist bundle is unchanged 1`] = `
     return 'middle';
   }
 
-  function renderLabelElement(renderLabel, labelProps) {
-    var label = renderLabel(labelProps);
-
-    if (typeof label === 'string' || typeof label === 'number') {
-      return /*#__PURE__*/React__default['default'].createElement(ReactMinimalPieChartLabel, Object.assign({
-        key: \\"label-\\" + (labelProps.dataEntry.key || labelProps.dataIndex)
-      }, labelProps), label);
-    }
-
-    if (React__default['default'].isValidElement(label)) {
-      return label;
-    }
-
-    return null;
-  }
-
-  function renderLabels(data, props) {
+  function makeLabelRenderProps(data, props) {
     return data.map(function (dataEntry, index) {
       var _functionProp;
 
@@ -191,8 +193,22 @@ exports[`Dist bundle is unchanged 1`] = `
         dataIndex: index,
         style: functionProp(props.labelStyle, index)
       };
-      return props.label && renderLabelElement(props.label, labelRenderProps);
+      return labelRenderProps;
     });
+  }
+
+  function renderLabels(data, props) {
+    var label = props.label;
+
+    if (label) {
+      return makeLabelRenderProps(data, props).map(function (labelRenderProps, index) {
+        return /*#__PURE__*/React__default['default'].createElement(ReactMinimalPieChartLabel, {
+          key: index,
+          renderLabel: label,
+          labelProps: labelRenderProps
+        });
+      });
+    }
   }
 
   var partialCircle = function partialCircle(cx, cy, r, start, end) {
@@ -385,7 +401,7 @@ exports[`Dist bundle is unchanged 1`] = `
       height: \\"100%\\",
       className: props.className,
       style: props.style
-    }, renderSegments(extendedData, props, revealOverride), props.label && renderLabels(extendedData, props), props.children);
+    }, renderSegments(extendedData, props, revealOverride), renderLabels(extendedData, props), props.children);
   }
 
   exports.PieChart = ReactMinimalPieChart;

--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -38,6 +38,17 @@ exports[`Dist bundle is unchanged 1`] = `
   function functionProp(prop, payload) {
     return typeof prop === 'function' ? prop(payload) : prop;
   }
+  function makePropsWithDefaults(props, defaultProps) {
+    var result = Object.assign({}, defaultProps, props); // @NOTE Object.assign doesn't default properties with undefined value (like React defaultProps does)
+
+    for (var key in defaultProps) {
+      if (props[key] === undefined) {
+        result[key] = defaultProps[key];
+      }
+    }
+
+    return result;
+  }
 
   function sumValues(data) {
     var sum = 0;
@@ -338,7 +349,10 @@ exports[`Dist bundle is unchanged 1`] = `
     startAngle: 0,
     viewBoxSize: [100, 100]
   };
-  function ReactMinimalPieChart(props) {
+  function ReactMinimalPieChart(originalProps) {
+    var props = makePropsWithDefaults(originalProps, // @ts-expect-error: defaultProps.data is typed as BaseDataEntry
+    defaultProps);
+
     var _useState = React.useState(props.animate ? 0 : null),
         revealOverride = _useState[0],
         setRevealOverride = _useState[1];
@@ -373,9 +387,9 @@ exports[`Dist bundle is unchanged 1`] = `
       style: props.style
     }, renderSegments(extendedData, props, revealOverride), props.label && renderLabels(extendedData, props), props.children);
   }
-  ReactMinimalPieChart.defaultProps = defaultProps;
 
   exports.PieChart = ReactMinimalPieChart;
+  exports.pieChartDefaultProps = defaultProps;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -117,7 +117,7 @@ export function ReactMinimalPieChart<DataEntry extends BaseDataEntry>(
       style={props.style}
     >
       {renderSegments(extendedData, props, revealOverride)}
-      {props.label && renderLabels(extendedData, props)}
+      {renderLabels(extendedData, props)}
       {props.children}
     </svg>
   );

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -15,6 +15,7 @@ import type {
   EventHandler,
   LabelRenderFunction,
 } from '../commonTypes';
+import { makePropsWithDefaults } from '../utils';
 
 export type Props<DataEntry extends BaseDataEntry = BaseDataEntry> = {
   animate?: boolean;
@@ -53,7 +54,7 @@ export type Props<DataEntry extends BaseDataEntry = BaseDataEntry> = {
   viewBoxSize?: [number, number];
 };
 
-const defaultProps = {
+export const defaultProps = {
   animationDuration: 500,
   animationEasing: 'ease-out',
   center: [50, 50] as [number, number],
@@ -72,11 +73,17 @@ export type PropsWithDefaults<
 > = Props<DataEntry> & typeof defaultProps;
 
 export function ReactMinimalPieChart<DataEntry extends BaseDataEntry>(
-  props: PropsWithDefaults<DataEntry>
+  originalProps: Props<DataEntry>
 ) {
+  const props = makePropsWithDefaults<PropsWithDefaults<DataEntry>>(
+    originalProps,
+    // @ts-expect-error: defaultProps.data is typed as BaseDataEntry
+    defaultProps
+  );
   const [revealOverride, setRevealOverride] = useState(
     props.animate ? 0 : null
   );
+
   useEffect(() => {
     if (props.animate) {
       return startInitialAnimation();
@@ -115,5 +122,3 @@ export function ReactMinimalPieChart<DataEntry extends BaseDataEntry>(
     </svg>
   );
 }
-
-ReactMinimalPieChart.defaultProps = defaultProps;

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -16,7 +16,7 @@ import type {
   LabelRenderFunction,
 } from '../commonTypes';
 
-type Props<DataEntry extends BaseDataEntry> = {
+export type Props<DataEntry extends BaseDataEntry = BaseDataEntry> = {
   animate?: boolean;
   animationDuration?: number;
   animationEasing?: string;

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -9,9 +9,14 @@ import type {
 import extendData from './extendData';
 import renderLabels from './renderLabels';
 import renderSegments from './renderSegments';
-import type { Data, EventHandler, LabelRenderFunction } from '../commonTypes';
+import type {
+  Data,
+  BaseDataEntry,
+  EventHandler,
+  LabelRenderFunction,
+} from '../commonTypes';
 
-type Props = {
+type Props<DataEntry extends BaseDataEntry> = {
   animate?: boolean;
   animationDuration?: number;
   animationEasing?: string;
@@ -19,10 +24,10 @@ type Props = {
   center?: [number, number];
   children?: ReactNode;
   className?: string;
-  data: Data;
+  data: Data<DataEntry>;
   lengthAngle?: number;
   lineWidth?: number;
-  label?: LabelRenderFunction;
+  label?: LabelRenderFunction<DataEntry>;
   labelPosition?: number;
   labelStyle?:
     | CSSProperties
@@ -62,9 +67,13 @@ const defaultProps = {
   viewBoxSize: [100, 100] as [number, number],
 };
 
-export type PropsWithDefaults = Props & typeof defaultProps;
+export type PropsWithDefaults<
+  DataEntry extends BaseDataEntry
+> = Props<DataEntry> & typeof defaultProps;
 
-export function ReactMinimalPieChart(props: PropsWithDefaults) {
+export function ReactMinimalPieChart<DataEntry extends BaseDataEntry>(
+  props: PropsWithDefaults<DataEntry>
+) {
   const [revealOverride, setRevealOverride] = useState(
     props.animate ? 0 : null
   );

--- a/src/Chart/extendData.ts
+++ b/src/Chart/extendData.ts
@@ -1,8 +1,10 @@
 import { extractPercentage, valueBetween } from '../utils';
-import type { Data, ExtendedData } from '../commonTypes';
+import type { Data, BaseDataEntry, ExtendedData } from '../commonTypes';
 import type { PropsWithDefaults as ChartProps } from './Chart';
 
-function sumValues(data: Data): number {
+function sumValues<DataEntry extends BaseDataEntry>(
+  data: Data<DataEntry>
+): number {
   let sum = 0;
   for (let i = 0; i < data.length; i++) {
     sum += data[i].value;
@@ -11,13 +13,13 @@ function sumValues(data: Data): number {
 }
 
 // Append "percentage", "degrees" and "startAngle" to each data entry
-export default function extendData({
+export default function extendData<DataEntry extends BaseDataEntry>({
   data,
   lengthAngle: totalAngle,
   totalValue,
   paddingAngle,
   startAngle: chartStartAngle,
-}: ChartProps): ExtendedData {
+}: ChartProps<DataEntry>): ExtendedData<DataEntry> {
   const total = totalValue || sumValues(data);
   const normalizedTotalAngle = valueBetween(totalAngle, -360, 360);
   const numberOfPaddings =
@@ -26,7 +28,7 @@ export default function extendData({
   const degreesTakenByPadding = singlePaddingDegrees * numberOfPaddings;
   const degreesTakenByPaths = normalizedTotalAngle - degreesTakenByPadding;
   let lastSegmentEnd = 0;
-  const extendedData = [];
+  const extendedData: ExtendedData<DataEntry> = [];
 
   // @NOTE: Shall we evaluate percentage accordingly to dataEntry.value's sign?
   for (let i = 0; i < data.length; i++) {

--- a/src/Chart/index.tsx
+++ b/src/Chart/index.tsx
@@ -1,2 +1,5 @@
-export { ReactMinimalPieChart as PieChart } from './Chart';
+export {
+  ReactMinimalPieChart as PieChart,
+  defaultProps as pieChartDefaultProps,
+} from './Chart';
 export type { Props as PieChartProps } from './Chart';

--- a/src/Chart/index.tsx
+++ b/src/Chart/index.tsx
@@ -1,1 +1,2 @@
 export { ReactMinimalPieChart as PieChart } from './Chart';
+export type { Props as PieChartProps } from './Chart';

--- a/src/Chart/renderLabels.tsx
+++ b/src/Chart/renderLabels.tsx
@@ -8,7 +8,11 @@ import {
 } from '../utils';
 import type { PropsWithDefaults as ChartProps } from './Chart';
 import type { LabelRenderProps } from '../Label';
-import type { ExtendedData, LabelRenderFunction } from '../commonTypes';
+import type {
+  ExtendedData,
+  LabelRenderFunction,
+  BaseDataEntry,
+} from '../commonTypes';
 
 function round(number: number): number {
   const divisor = 1e14; // 14 decimals
@@ -42,9 +46,9 @@ function evaluateTextAnchorPosition({
   return 'middle';
 }
 
-function renderLabelElement(
-  renderLabel: LabelRenderFunction,
-  labelProps: LabelRenderProps
+function renderLabelElement<DataEntry extends BaseDataEntry>(
+  renderLabel: LabelRenderFunction<DataEntry>,
+  labelProps: LabelRenderProps<DataEntry>
 ): JSX.Element | null {
   const label = renderLabel(labelProps);
   if (typeof label === 'string' || typeof label === 'number') {
@@ -64,7 +68,10 @@ function renderLabelElement(
   return null;
 }
 
-export default function renderLabels(data: ExtendedData, props: ChartProps) {
+export default function renderLabels<DataEntry extends BaseDataEntry>(
+  data: ExtendedData<DataEntry>,
+  props: ChartProps<DataEntry>
+) {
   return data.map((dataEntry, index) => {
     const segmentsShift = functionProp(props.segmentsShift, index) ?? 0;
     const distanceFromCenter =

--- a/src/Chart/renderSegments.tsx
+++ b/src/Chart/renderSegments.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { CSSProperties } from 'react';
 import Path from '../Path';
 import { extractPercentage, functionProp, isNumber } from '../utils';
-import type { ExtendedData } from '../commonTypes';
+import type { ExtendedData, BaseDataEntry } from '../commonTypes';
 import type { PropsWithDefaults as ChartProps } from './Chart';
 
 function combineSegmentTransitionsStyle(
@@ -40,9 +40,9 @@ function makeEventHandler<Event, EventHandler, Payload>(
   );
 }
 
-export default function renderSegments(
-  data: ExtendedData,
-  props: ChartProps,
+export default function renderSegments<DataEntry extends BaseDataEntry>(
+  data: ExtendedData<DataEntry>,
+  props: ChartProps<DataEntry>,
   revealOverride?: null | number
 ) {
   // @NOTE this should go in Path component. Here for performance reasons

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -1,24 +1,23 @@
 import React from 'react';
 import type { CSSProperties, SVGProps } from 'react';
-import type { ExtendedDataEntry } from './commonTypes';
+import type { ExtendedData, BaseDataEntry } from './commonTypes';
 
-export type LabelRenderProps = {
+export type LabelRenderProps<DataEntry extends BaseDataEntry> = {
   x: number;
   y: number;
   dx: number;
   dy: number;
   textAnchor: string;
-  dataEntry: ExtendedDataEntry;
+  dataEntry: ExtendedData<DataEntry>[number];
   dataIndex: number;
   style?: CSSProperties;
 };
 
-type Props = SVGProps<SVGTextElement> & LabelRenderProps;
+type Props<DataEntry extends BaseDataEntry> = SVGProps<SVGTextElement> &
+  LabelRenderProps<DataEntry>;
 
-export default function ReactMinimalPieChartLabel({
-  dataEntry,
-  dataIndex,
-  ...props
-}: Props) {
+export default function ReactMinimalPieChartLabel<
+  DataEntry extends BaseDataEntry
+>({ dataEntry, dataIndex, ...props }: Props<DataEntry>) {
   return <text dominantBaseline="central" {...props} />;
 }

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import type { CSSProperties, SVGProps } from 'react';
-import type { ExtendedData, BaseDataEntry } from './commonTypes';
+import type {
+  ExtendedData,
+  BaseDataEntry,
+  LabelRenderFunction,
+} from './commonTypes';
 
 export type LabelRenderProps<DataEntry extends BaseDataEntry> = {
   x: number;
@@ -13,11 +17,38 @@ export type LabelRenderProps<DataEntry extends BaseDataEntry> = {
   style?: CSSProperties;
 };
 
-type Props<DataEntry extends BaseDataEntry> = SVGProps<SVGTextElement> &
-  LabelRenderProps<DataEntry>;
+function ReactMinimalPieChartDefaultLabel<DataEntry extends BaseDataEntry>({
+  dataEntry,
+  dataIndex,
+  ...props
+}: SVGProps<SVGTextElement> & LabelRenderProps<DataEntry>) {
+  return <text dominantBaseline="central" {...props} />;
+}
 
 export default function ReactMinimalPieChartLabel<
   DataEntry extends BaseDataEntry
->({ dataEntry, dataIndex, ...props }: Props<DataEntry>) {
-  return <text dominantBaseline="central" {...props} />;
+>({
+  renderLabel,
+  labelProps,
+}: {
+  renderLabel: LabelRenderFunction<DataEntry>;
+  labelProps: LabelRenderProps<DataEntry>;
+}) {
+  const label = renderLabel(labelProps);
+  if (typeof label === 'string' || typeof label === 'number') {
+    return (
+      <ReactMinimalPieChartDefaultLabel
+        key={`label-${labelProps.dataEntry.key || labelProps.dataIndex}`}
+        {...labelProps}
+      >
+        {label}
+      </ReactMinimalPieChartDefaultLabel>
+    );
+  }
+
+  if (React.isValidElement(label)) {
+    return label;
+  }
+
+  return null;
 }

--- a/src/__tests__/Chart.test.tsx
+++ b/src/__tests__/Chart.test.tsx
@@ -1,7 +1,8 @@
 // @ts-nocheck
 import React from 'react';
-import { act, render, dataMock, getArcInfo, PieChart } from './testUtils';
+import { act, render, dataMock, getArcInfo } from './testUtils';
 import { degreesToRadians, extractPercentage } from '../utils';
+import { pieChartDefaultProps } from '../../src';
 
 jest.useFakeTimers();
 
@@ -187,8 +188,8 @@ describe('Chart', () => {
       ${25}        | ${25}
     `('reveal === ${reveal}', ({ reveal, expectedRevealedPercentage }) => {
       it('re-render on did mount revealing the expected portion of segment', () => {
-        const segmentRadius = PieChart.defaultProps.radius / 2;
-        const lengthAngle = PieChart.defaultProps.lengthAngle;
+        const segmentRadius = pieChartDefaultProps.radius / 2;
+        const lengthAngle = pieChartDefaultProps.lengthAngle;
         const fullPathLength = degreesToRadians(segmentRadius) * lengthAngle;
         let hiddenPercentage;
         const initialProps = {

--- a/src/__tests__/Label.test.tsx
+++ b/src/__tests__/Label.test.tsx
@@ -1,11 +1,12 @@
 // @ts-nocheck
 import React from 'react';
-import { render, dataMock, PieChart, getArcInfo } from './testUtils';
+import { render, dataMock, getArcInfo } from './testUtils';
 import {
   bisectorAngle,
   extractPercentage,
   shiftVectorAlongAngle,
 } from '../utils';
+import { pieChartDefaultProps } from '../../src';
 
 function getExpectedLabelRenderProps(dataEntry) {
   return {
@@ -110,11 +111,11 @@ describe('Label', () => {
 
             expect(label).toHaveAttribute(
               'x',
-              `${PieChart.defaultProps.center[0]}`
+              `${pieChartDefaultProps.center[0]}`
             );
             expect(label).toHaveAttribute(
               'y',
-              `${PieChart.defaultProps.center[1]}`
+              `${pieChartDefaultProps.center[1]}`
             );
             expect(label).toHaveAttribute('dx', `${dx}`);
             expect(label).toHaveAttribute('dy', `${dy}`);

--- a/src/__tests__/types.tsx
+++ b/src/__tests__/types.tsx
@@ -58,3 +58,14 @@ import { PieChart } from '../../src';
 <PieChart data={[]}>
   <defs />
 </PieChart>;
+
+<PieChart
+  data={[
+    { value: 10, color: 'blue', custom: 'foo' },
+    { value: 15, color: 'orange', custom: 'bar' },
+  ]}
+  label={(labelRenderProps) => {
+    const customProp: string = labelRenderProps.dataEntry.custom;
+    return null;
+  }}
+/>;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -1,11 +1,11 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import type { LabelRenderProps } from './Label';
 
 export type EventHandler<Event> = (event: Event, dataIndex: number) => void;
 
 export type LabelRenderFunction<DataEntry extends BaseDataEntry> = (
   labelRenderProps: LabelRenderProps<DataEntry>
-) => number | string | ReactElement | undefined | null;
+) => ReactNode;
 
 export type BaseDataEntry = {
   title?: string | number;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -3,23 +3,26 @@ import type { LabelRenderProps } from './Label';
 
 export type EventHandler<Event> = (event: Event, dataIndex: number) => void;
 
-export type LabelRenderFunction = (
-  labelRenderProps: LabelRenderProps
+export type LabelRenderFunction<DataEntry extends BaseDataEntry> = (
+  labelRenderProps: LabelRenderProps<DataEntry>
 ) => number | string | ReactElement | undefined | null;
 
-export type DataEntry = {
+export type BaseDataEntry = {
   title?: string | number;
   color: string;
   value: number;
   key?: string | number;
-  [key: string]: any;
 };
 
-export type ExtendedDataEntry = DataEntry & {
+type BaseExtendedDataEntry<
+  DataEntry extends BaseDataEntry = BaseDataEntry
+> = DataEntry & {
   degrees: number;
   startAngle: number;
   percentage: number;
 };
 
-export type Data = DataEntry[];
-export type ExtendedData = ExtendedDataEntry[];
+export type Data<DataEntry extends BaseDataEntry = BaseDataEntry> = DataEntry[];
+export type ExtendedData<
+  DataEntry extends BaseDataEntry = BaseDataEntry
+> = BaseExtendedDataEntry<DataEntry>[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { PieChart } from './Chart';
+export { PieChart, pieChartDefaultProps } from './Chart';
 export type { PieChartProps } from './Chart';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { PieChart } from './Chart';
+export type { PieChartProps } from './Chart';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,19 @@ export function functionProp<Prop, Payload>(
 ): Prop extends (...args: any) => any ? ReturnType<Prop> : Prop {
   return typeof prop === 'function' ? prop(payload) : prop;
 }
+
+export function makePropsWithDefaults<Result extends Object>(
+  props: Partial<Result>,
+  defaultProps: Result
+): Result {
+  const result: Result = Object.assign({}, defaultProps, props);
+
+  // @NOTE Object.assign doesn't default properties with undefined value (like React defaultProps does)
+  for (const key in defaultProps) {
+    if (props[key] === undefined) {
+      result[key] = defaultProps[key];
+    }
+  }
+
+  return result;
+}

--- a/stories/FullOption.tsx
+++ b/stories/FullOption.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PieChart, PieChartProps } from '../src';
+import { PieChart, pieChartDefaultProps, PieChartProps } from '../src';
 
 function FullOption(props: PieChartProps) {
   const [selected, setSelected] = useState<number | undefined>(0);
@@ -25,7 +25,7 @@ function FullOption(props: PieChartProps) {
         fontSize: '8px',
       }}
       data={data}
-      radius={PieChart.defaultProps.radius - 6}
+      radius={pieChartDefaultProps.radius - 6}
       lineWidth={60}
       segmentsStyle={{ transition: 'stroke .3s', cursor: 'pointer' }}
       segmentsShift={(index) => (index === selected ? 6 : 1)}

--- a/stories/FullOption.tsx
+++ b/stories/FullOption.tsx
@@ -1,11 +1,7 @@
-import React, { useState, ComponentProps } from 'react';
-import { PieChart } from '../src';
+import React, { useState } from 'react';
+import { PieChart, PieChartProps } from '../src';
 
-type Props = {
-  data: ComponentProps<typeof PieChart>['data'];
-};
-
-function FullOption(props: Props) {
+function FullOption(props: PieChartProps) {
   const [selected, setSelected] = useState<number | undefined>(0);
   const [hovered, setHovered] = useState<number | undefined>(undefined);
 

--- a/stories/InteractionStory.tsx
+++ b/stories/InteractionStory.tsx
@@ -1,12 +1,8 @@
-import React, { useState, ComponentProps } from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { PieChart } from '../src';
+import { PieChart, PieChartProps } from '../src';
 
-type Props = {
-  data: ComponentProps<typeof PieChart>['data'];
-};
-
-function DemoInteraction(props: Props) {
+function DemoInteraction(props: PieChartProps) {
   const [selected, setSelected] = useState<number | undefined>(0);
   const [hovered, setHovered] = useState<number | undefined>(undefined);
 

--- a/stories/InteractionStory.tsx
+++ b/stories/InteractionStory.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { PieChart, PieChartProps } from '../src';
+import { PieChart, pieChartDefaultProps, PieChartProps } from '../src';
 
 function DemoInteraction(props: PieChartProps) {
   const [selected, setSelected] = useState<number | undefined>(0);
@@ -19,7 +19,7 @@ function DemoInteraction(props: PieChartProps) {
   return (
     <PieChart
       data={data}
-      radius={PieChart.defaultProps.radius - 6}
+      radius={pieChartDefaultProps.radius - 6}
       segmentsStyle={{ transition: 'stroke .3s', cursor: 'pointer' }}
       segmentsShift={(index) => (index === selected ? 6 : 1)}
       onClick={(event, index) => {

--- a/stories/InteractionTabStory.tsx
+++ b/stories/InteractionTabStory.tsx
@@ -1,12 +1,8 @@
-import React, { useState, ComponentProps } from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { PieChart } from '../src';
+import { PieChart, PieChartProps } from '../src';
 
-type Props = {
-  data: ComponentProps<typeof PieChart>['data'];
-};
-
-function DemoInteractionTab(props: Props) {
+function DemoInteractionTab(props: PieChartProps) {
   const [selected, setSelected] = useState<undefined | number>(0);
   const [focused, setFocused] = useState<undefined | number>(undefined);
 

--- a/stories/Tooltip.tsx
+++ b/stories/Tooltip.tsx
@@ -6,7 +6,9 @@ type Props = {
   data: ComponentProps<typeof PieChart>['data'];
 };
 
-function makeTooltipContent(entry: Props['data'][0]) {
+function makeTooltipContent(
+  entry: Props['data'][0] & { tooltip: Props['data'][0]['title'] }
+) {
   return `Sector ${entry.tooltip} has value ${entry.value}`;
 }
 

--- a/stories/Tooltip.tsx
+++ b/stories/Tooltip.tsx
@@ -1,18 +1,18 @@
-import React, { useState, ComponentProps } from 'react';
+import React, { useState } from 'react';
 import ReactTooltip from 'react-tooltip';
-import { PieChart } from '../src';
+import { PieChart, PieChartProps } from '../src';
 
-type Props = {
-  data: ComponentProps<typeof PieChart>['data'];
-};
+type BaseData = PieChartProps['data'][number];
 
 function makeTooltipContent(
-  entry: Props['data'][0] & { tooltip: Props['data'][0]['title'] }
+  entry: BaseData & {
+    tooltip: BaseData['title'];
+  }
 ) {
   return `Sector ${entry.tooltip} has value ${entry.value}`;
 }
 
-function ToolTip(props: Props) {
+function ToolTip(props: PieChartProps) {
   const [hovered, setHovered] = useState<number | null>(null);
   const data = props.data.map(({ title, ...entry }) => {
     return {

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { PieChart } from '../src';
+import { PieChart, pieChartDefaultProps } from '../src';
 import FullOption from './FullOption';
 import InteractionStory from './InteractionStory';
 import InteractionTabStory from './InteractionTabStory';
@@ -30,7 +30,7 @@ storiesOf('Pie Chart', module)
     return (
       <PieChart
         data={dataMock}
-        radius={PieChart.defaultProps.radius - shiftSize}
+        radius={pieChartDefaultProps.radius - shiftSize}
         segmentsShift={(index) => (index === 0 ? shiftSize : 0.5)}
         label={({ dataEntry }) => dataEntry.value}
         labelStyle={{


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Feature

### What is the current behaviour? _(You can also link to an open issue here)_

`data` doesn't consider any custom prop

### What is the new behaviour?

Type `data` props with generics and expose `PieChartProps` type.

Remove dependency over React's deprecated `defaultProps`.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
