### PR TITLE
refactor: trigger initial animation with useEffect only

### DIFF
--- a/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__tests__/__snapshots__/bundles-snapshot.test.js.snap
@@ -346,26 +346,6 @@ exports[`Dist bundle is unchanged 1`] = `
     return paths;
   }
 
-  function useEffectAfterFirstPaint(effect) {
-    React.useEffect(function () {
-      if (effect) {
-        var timerId;
-        var RAFId;
-        timerId = setTimeout(function () {
-          timerId = null;
-          RAFId = requestAnimationFrame(function () {
-            effect();
-            RAFId = null;
-          });
-        });
-        return function () {
-          timerId && clearTimeout(timerId);
-          RAFId && cancelAnimationFrame(RAFId);
-        };
-      }
-    }, []);
-  }
-
   var defaultProps = {
     animationDuration: 500,
     animationEasing: 'ease-out',
@@ -387,10 +367,12 @@ exports[`Dist bundle is unchanged 1`] = `
         revealOverride = _useState[0],
         setRevealOverride = _useState[1];
 
-    useEffectAfterFirstPaint(props.animate ? function () {
-      // Trigger initial animation
-      setRevealOverride(null);
-    } : undefined);
+    React.useEffect(function () {
+      if (props.animate) {
+        // Trigger initial animation
+        setRevealOverride(null);
+      }
+    }, []);
     var extendedData = extendData(props);
     return /*#__PURE__*/React__default['default'].createElement(\\"svg\\", {
       viewBox: \\"0 0 \\" + props.viewBoxSize[0] + \\" \\" + props.viewBoxSize[1],

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -12,27 +12,6 @@ import renderSegments from './renderSegments';
 import type { Data, BaseDataEntry, LabelRenderFunction } from '../commonTypes';
 import { makePropsWithDefaults } from '../utils';
 
-function useEffectAfterFirstPaint(effect?: () => void) {
-  useEffect(() => {
-    if (effect) {
-      let timerId: NodeJS.Timeout | null;
-      let RAFId: number | null;
-      timerId = setTimeout(() => {
-        timerId = null;
-        RAFId = requestAnimationFrame(() => {
-          effect();
-          RAFId = null;
-        });
-      });
-
-      return () => {
-        timerId && clearTimeout(timerId);
-        RAFId && cancelAnimationFrame(RAFId);
-      };
-    }
-  }, []);
-}
-
 export type Props<DataEntry extends BaseDataEntry = BaseDataEntry> = {
   animate?: boolean;
   animationDuration?: number;
@@ -100,14 +79,12 @@ export function ReactMinimalPieChart<DataEntry extends BaseDataEntry>(
     props.animate ? 0 : null
   );
 
-  useEffectAfterFirstPaint(
-    props.animate
-      ? () => {
-          // Trigger initial animation
-          setRevealOverride(null);
-        }
-      : undefined
-  );
+  useEffect(() => {
+    if (props.animate) {
+      // Trigger initial animation
+      setRevealOverride(null);
+    }
+  }, []);
 
   const extendedData = extendData(props);
   return (


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Refactor

### What is the current behaviour? _(You can also link to an open issue here)_

Initial animation triggered on `useEffect` + `setTimeout` + `requestAnimationFrame`

### What is the new behaviour?

Triggering a state update with `useEffect` should be enough to guarantee that the component is initially painted with hidden segments and then animation is triggered.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No, it shouldn't. Should we run into regression bug we can safely revert this commit.

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
