### PR TITLE
fix(Path): render <title> when title is `0`

### DIFF
--- a/.changeset/curvy-pigs-obey.md
+++ b/.changeset/curvy-pigs-obey.md
@@ -1,0 +1,5 @@
+---
+"react-minimal-pie-chart": patch
+---
+
+Render <title> when title is `0`

--- a/src/Path.tsx
+++ b/src/Path.tsx
@@ -92,7 +92,7 @@ export default function ReactMinimalPieChartPath({
       strokeLinecap={rounded ? 'round' : undefined}
       {...props}
     >
-      {title && <title>{title}</title>}
+      {title != null && <title>{title}</title>}
     </path>
   );
 }

--- a/test/Path.test.tsx
+++ b/test/Path.test.tsx
@@ -53,6 +53,30 @@ describe('Path', () => {
     });
   });
 
+  describe('data[].title prop', () => {
+    it('renders a "<title>" element, including when title is 0', () => {
+      const { container } = render({
+        data: [
+          { value: 10, color: 'blue', title: 'first' },
+          { value: 15, color: 'orange', title: 0 },
+        ],
+      });
+      const paths = container.querySelectorAll('path');
+
+      expect(paths[0].querySelector('title')).toHaveTextContent('first');
+      expect(paths[1].querySelector('title')).toHaveTextContent('0');
+      // No stray text node should be rendered as a direct child of <path>
+      expect(paths[1].childNodes).toHaveLength(1);
+    });
+
+    it('renders no "<title>" element when title is undefined', () => {
+      const { container } = render();
+      const path = container.querySelector('path');
+
+      expect(path?.querySelector('title')).toBeNull();
+    });
+  });
+
   describe('segmentsStyle prop', () => {
     describe.each`
       description      | segmentsStyle                              | expectedStyle

--- a/test/Path.test.tsx
+++ b/test/Path.test.tsx
@@ -53,8 +53,8 @@ describe('Path', () => {
     });
   });
 
-  describe('data[].title prop', () => {
-    it('renders a "<title>" element, including when title is 0', () => {
+  describe('data[].title prop === 0', () => {
+    it('renders a "<title>" element', () => {
       const { container } = render({
         data: [
           { value: 10, color: 'blue', title: 'first' },


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

...

- Bug fix

### What is the current behaviour? _(You can also link to an open issue here)_

...
In `src/Path.tsx`, the segment's accessible <title> element is rendered via {`title && <title>{title}</title>`}. 
Since title accepts `string | number`, passing a numeric title of 0 (e.g. a 0-value segment) makes the && short-circuit on the falsy number 0. 
So, this drops the <title> element entirely and instead renders the literal 0 as a stray text node directly inside the <path> element.

### What is the new behaviour?

...

The condition now checks title != null instead of relying on truthiness, so title={0} correctly renders <title>0</title> and no stray text node is emitted. 
`title={undefined}` still renders nothing, as before.  Added a test in `test/Path.test.tsx` covering both a normal string title and title={0}.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

...

- No

### Other information:

- None

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated