### PR TITLE
refactor: clarify arc-length formula and drop unused import

### DIFF
--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { CSSProperties, SVGProps } from 'react';
+import type { CSSProperties } from 'react';
 import type {
   ExtendedData,
   BaseDataEntry,

--- a/src/Path.tsx
+++ b/src/Path.tsx
@@ -76,7 +76,7 @@ export default function ReactMinimalPieChartPath({
   // Animate/hide paths with "stroke-dasharray" + "stroke-dashoffset"
   // https://css-tricks.com/svg-line-animation-works/
   if (isNumber(reveal)) {
-    const pathLength = degreesToRadians(pathRadius) * lengthAngle;
+    const pathLength = pathRadius * degreesToRadians(lengthAngle);
     strokeDasharray = Math.abs(pathLength);
     strokeDashoffset =
       strokeDasharray - extractPercentage(strokeDasharray, reveal);

--- a/test-bundles/__snapshots__/bundles-snapshot.test.ts.snap
+++ b/test-bundles/__snapshots__/bundles-snapshot.test.ts.snap
@@ -155,7 +155,7 @@ function ReactMinimalPieChartPath({ cx, cy, lengthAngle, lineWidth, radius, shif
     // Animate/hide paths with "stroke-dasharray" + "stroke-dashoffset"
     // https://css-tricks.com/svg-line-animation-works/
     if (isNumber(reveal)) {
-        const pathLength = degreesToRadians(pathRadius) * lengthAngle;
+        const pathLength = pathRadius * degreesToRadians(lengthAngle);
         strokeDasharray = Math.abs(pathLength);
         strokeDashoffset =
             strokeDasharray - extractPercentage(strokeDasharray, reveal);


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Refactor / code cleanup (no behavior change)

### What is the current behaviour? _(You can also link to an open issue here)_

- `Path.tsx` computes the animated path length as degreesToRadians(pathRadius) * lengthAngle. This is numerically correct only because multiplication is commutative with the intended formula (pathRadius * degreesToRadians(lengthAngle)), but calling `degreesToRadians()` on a radius (not an angle) is misleading and risks a future "fix" that breaks it.
- `Label.tsx` imports SVG Props from react but never uses it.

### What is the new behaviour?

- pathLength is now written as pathRadius * degreesToRadians(lengthAngle), matching the actual arc-length formula (radius × angle in radians), with an identical numeric result.                                                                                                                           
- Removed the unused SVGProps import from `Label.tsx`.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No.

### Other information:

None.

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
